### PR TITLE
Cookiebar event tracking

### DIFF
--- a/frontend/themes/bootstrap/core/coffee/theme_new.coffee
+++ b/frontend/themes/bootstrap/core/coffee/theme_new.coffee
@@ -50,6 +50,14 @@ class DefaultTheme extends Theme
     utils.cookies.setCookie('cookie_bar_agree', 'b:1;')
     utils.cookies.setCookie('cookie_bar_hide', 'b:1;')
     $('#cookieBar').alert('close')
+    if ga?
+      ga(
+          'send',
+          'event',
+          'cookiebar',
+          'agree'
+      )
+
     if _gaq?
       _gaq.push([
         '_trackEvent',
@@ -62,6 +70,14 @@ class DefaultTheme extends Theme
     utils.cookies.setCookie('cookie_bar_agree', 'b:0;')
     utils.cookies.setCookie('cookie_bar_hide', 'b:1;')
     $('#cookieBar').alert('close')
+    if ga?
+      ga(
+          'send',
+          'event',
+          'cookiebar',
+          'disagree'
+      )
+
     if _gaq?
       _gaq.push([
         '_trackEvent',
@@ -72,6 +88,14 @@ class DefaultTheme extends Theme
     false
 
   cookieBarHide: ->
+    if ga?
+      ga(
+        'send',
+        'event',
+        'cookiebar',
+        'hide'
+      )
+
     if _gaq?
       _gaq.push([
         '_trackEvent',

--- a/frontend/themes/bootstrap/core/js/theme_new.js
+++ b/frontend/themes/bootstrap/core/js/theme_new.js
@@ -119,6 +119,9 @@
       utils.cookies.setCookie('cookie_bar_agree', 'b:1;');
       utils.cookies.setCookie('cookie_bar_hide', 'b:1;');
       $('#cookieBar').alert('close');
+      if (typeof ga !== "undefined" && ga !== null) {
+        ga('send', 'event', 'cookiebar', 'agree');
+      }
       if (typeof _gaq !== "undefined" && _gaq !== null) {
         _gaq.push(['_trackEvent', 'cookiebar', 'agree']);
       }
@@ -129,6 +132,9 @@
       utils.cookies.setCookie('cookie_bar_agree', 'b:0;');
       utils.cookies.setCookie('cookie_bar_hide', 'b:1;');
       $('#cookieBar').alert('close');
+      if (typeof ga !== "undefined" && ga !== null) {
+        ga('send', 'event', 'cookiebar', 'disagree');
+      }
       if (typeof _gaq !== "undefined" && _gaq !== null) {
         _gaq.push(['_trackEvent', 'cookiebar', 'disagree']);
       }
@@ -136,6 +142,9 @@
     };
 
     DefaultTheme.prototype.cookieBarHide = function() {
+      if (typeof ga !== "undefined" && ga !== null) {
+        ga('send', 'event', 'cookiebar', 'hide');
+      }
       if (typeof _gaq !== "undefined" && _gaq !== null) {
         _gaq.push(['_trackEvent', 'cookiebar', 'hide']);
       }


### PR DESCRIPTION
Use event tracking on the cookie bar, so we can see how many times it is hidden, agreed, disagreed
