### PR TITLE
fix pagination urls when relative to querystring

### DIFF
--- a/frontend/core/engine/base.php
+++ b/frontend/core/engine/base.php
@@ -470,7 +470,7 @@ class FrontendBaseBlock extends FrontendBaseObject
 		if(!isset($this->pagination['url'])) throw new FrontendException('no URL available in the pagination-property.');
 
 		// should we use a questionmark or an ampersand
-		if(mb_strpos($this->pagination['url'], '?') > 0) $useQuestionMark = false;
+        $useQuestionMark = (mb_strpos($this->pagination['url'], '?') === false);
 
 		// no pagination needed
 		if($this->pagination['num_pages'] < 1) return;


### PR DESCRIPTION
When you have an url relative to the querystring  (eg "?order=price"), the url builder fails and will use a second "?" for the next query parameter. This will fix that problem
