### PR TITLE
catch the \Exception that is thrown if the file is missing

### DIFF
--- a/src/Backend/Modules/Extensions/Engine/Model.php
+++ b/src/Backend/Modules/Extensions/Engine/Model.php
@@ -558,7 +558,7 @@ class Model
                         }
                     }
                 }
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 // don't act upon error, we simply won't possess some info
             }
 


### PR DESCRIPTION
It was catching Exception, but that was mapped to Backend\Core\Engine\Exception so it didn't work