### PR TITLE
Set debugmode to true on staging-server

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,6 +28,17 @@ use Symfony\Component\Debug\Debug;
 $env = getenv('FORK_ENV') ? : 'prod';
 $debug = getenv('FORK_DEBUG') === '1';
 
+/**
+ * @remark only for SumoCoders
+ *
+ * Because ENV variables are not passed to CGI due to suExec.
+ * See http://wiki.dreamhost.com/Suexec#Apache_module_mod_env for more
+ * information.
+ */
+if (isset($_SERVER['HTTP_HOST']) && substr_count($_SERVER['HTTP_HOST'], '.sumocoders.eu') >= 1) {
+    $debug = true;
+}
+
 // Fork has not yet been installed
 $parametersFile = dirname(__FILE__) . '/app/config/parameters.yml';
 $request = Request::createFromGlobals();

--- a/index.php
+++ b/index.php
@@ -28,17 +28,6 @@ use Symfony\Component\Debug\Debug;
 $env = getenv('FORK_ENV') ? : 'prod';
 $debug = getenv('FORK_DEBUG') === '1';
 
-/**
- * @remark only for SumoCoders
- *
- * Because ENV variables are not passed to CGI due to suExec.
- * See http://wiki.dreamhost.com/Suexec#Apache_module_mod_env for more
- * information.
- */
-if (isset($_SERVER['HTTP_HOST']) && substr_count($_SERVER['HTTP_HOST'], '.sumocoders.eu') >= 1) {
-    $debug = true;
-}
-
 // Fork has not yet been installed
 $parametersFile = dirname(__FILE__) . '/app/config/parameters.yml';
 $request = Request::createFromGlobals();

--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -600,6 +600,20 @@ class Header extends FrontendBaseObject
             );
         }
 
+        /**
+         * @remark only for SumoCoders
+         *
+         * Because ENV variables are not passed to CGI due to suExec.
+         * See http://wiki.dreamhost.com/Suexec#Apache_module_mod_env for more
+         * information.
+         */
+        if (isset($_SERVER['HTTP_HOST']) && substr_count($_SERVER['HTTP_HOST'], '.sumocoders.eu') >= 1) {
+            $this->addMetaData(
+                array('name' => 'robots', 'content' => 'noindex, nofollow'),
+                true
+            );
+        }
+
         $this->parseMetaAndLinks();
         $this->parseCSS();
         $this->parseJS();


### PR DESCRIPTION
Because the robots-meta-tag is only inserted when debug is true, we need debug
to be true on the staging-server.

We can't solve this with ENV-variables because they aren't passed due a
documented issue with suExec and mod_env, see http://wiki.dreamhost.com/Suexec#Apache_module_mod_env
for more information.