### PR TITLE
Fix usertemplates with high id's

### DIFF
--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -119,7 +119,7 @@ jsBackend.pages.extras =
 	addBlockVisual: function(position, index, extraId, visible, extraType)
 	{
 		// check if the extra is valid
-		if(extraId != 0 && typeof extrasById[extraId] == 'undefined') return false;
+		if(extraType != 'usertemplate' && extraId != 0 && typeof extrasById[extraId] == 'undefined') return false;
 
 		// block
 		var editLink, title, description;


### PR DESCRIPTION
If our usertemplate had an id bigger then the highest extraId, the visual representation was never shown.
This makes sure this check does not apply to user templates anymore