### PR TITLE
Fetch the IE shims using the currently used protocol.

### DIFF
--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Head.tpl
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Head.tpl
@@ -37,9 +37,9 @@
 
 	<!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
 	<!--[if lt IE 9]>
-		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.6.2/modernizr.min.js"></script>
+		<script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.6.2/modernizr.min.js"></script>
 	<![endif]-->
 
 	{option:SPOON_DEBUG}


### PR DESCRIPTION
This avoids mixed content warnings.