### PR TITLE
Run clean before everything else in gulp build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var autoprefixer = require('gulp-autoprefixer'),
     livereload = require('gulp-livereload'),
     plumber = require('gulp-plumber'),
     rename = require('gulp-rename'),
+    runSequence = require('run-sequence'),
     sass = require('gulp-sass'),
     sourcemaps = require('gulp-sourcemaps'),
     gulpWebpack = require('webpack-stream'),
@@ -153,5 +154,5 @@ gulp.task('serve', function() {
 });
 
 gulp.task('build', function() {
-  gulp.start('clean', 'iconfont', 'fontgen', 'sass:build', 'webpack:build', 'copy:templates', 'imagemin');
+  runSequence('clean', ['iconfont', 'fontgen', 'sass:build', 'webpack:build', 'copy:templates', 'imagemin']);
 });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "lodash": "^4.6.1",
     "node-sass": "^3.4.2",
+    "run-sequence": "^1.1.5",
     "sass-loader": "^3.1.2",
     "webpack": "^1.12.14",
     "webpack-stream": "^3.1.0"


### PR DESCRIPTION
Make sure the clean task is finished before doing all the other stuff in gulp build, otherwise weird errors might pop up.