### PR TITLE
Fix link in cookie bar text in Bootstrap theme

### DIFF
--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Notifications.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Notifications.html.twig
@@ -16,7 +16,7 @@
     <div class="container">
 
       <div class="cookiebar-content">
-        <strong>{{ 'lbl.Warning'|trans|capitalize }}:</strong> {{ 'msg.Cookies'|trans }}
+        <strong>{{ 'lbl.Warning'|trans|capitalize }}:</strong> {{ 'msg.Cookies'|trans|raw }}
       </div>
 
       <div class="cookiebar-buttons">


### PR DESCRIPTION
Link in cookie bar doesn't work without raw modifier: https://cloudup.com/cK1OMh3vjqa