### PR TITLE
Don't include widgets anymore.

### DIFF
--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Default.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Default.html.twig
@@ -10,8 +10,6 @@
     {% for main in positions.main %}
       {% if main.html %}
         {{ main.html|raw }}
-      {% else %}
-        {% include main.include_path %}
       {% endif %}
     {% endfor %}
   </div>

--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Error.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Error.html.twig
@@ -15,8 +15,6 @@
     {% for main in positions.main %}
       {% if main.html %}
         {{ main.html|raw }}
-      {% else %}
-        {% include main.include_path %}
       {% endif %}
     {% endfor %}
   </div>

--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Home.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Home.html.twig
@@ -6,8 +6,6 @@
     {% for main in positions.main %}
       {% if main.html %}
         {{ main.html|raw }}
-      {% elseif main.include_path %}
-        {% include main.include_path %}
       {% endif %}
     {% endfor %}
   </div>

--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Navbar.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Navbar.html.twig
@@ -20,8 +20,6 @@
     {% for top in positions.top %}
       {% if top.html %}
         {{ top.html|raw }}
-      {% elseif top.include_path %}
-        {% include top.include_path %}
       {% endif %}
     {% endfor %}
 

--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Sidebar.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Sidebar.html.twig
@@ -10,8 +10,6 @@
     {% for main in positions.main %}
       {% if main.html %}
         {{ main.html|raw }}
-      {% else %}
-        {% include main.include_path %}
       {% endif %}
     {% endfor %}
   </div>


### PR DESCRIPTION
Every block is now parsed in php then sent to the template. If it was
getting in the include_path block, this meant that a block outputted
empty html, causing an error to be thrown.