### PR TITLE
Fix distribute-height utility so it works for all browsers

### DIFF
--- a/src/Frontend/Themes/Bootstrap/src/Js/utilities/distribute-height.js
+++ b/src/Frontend/Themes/Bootstrap/src/Js/utilities/distribute-height.js
@@ -42,10 +42,10 @@ export default class {
 
             // Set the height of the same types of items
             keys = Object.keys(maxHeights);
-            for (key of keys) {
+            for (var i = 0; i < keys.length; i++) {
+                key = keys[i];
                 $this.find('[data-mh=' + key + ']').height(maxHeights[key]);
             }
-
         });
     }
 }


### PR DESCRIPTION
Not all browsers support the for...of... notation yet, so we went old school again.