### PR TITLE
Add Errbit dependency back to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "google/apiclient": "~1.1.2",
         "league/flysystem": "~1.0",
 
+        "flippa-official/errbit-php": "dev-master#b432716d29c2b4ada0f21ccc469ccb046bb60340",
         "sumocoders/sumo-fork-class": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
It will fix issues with composer when trying to add new dependencies. As our
minimum dependency is stable and the flippa-official/errbit-php is not.