### PR TITLE
Use a comma as a separator for a twig function

### DIFF
--- a/src/Frontend/Themes/Bootstrap/Modules/Profiles/Layout/Widgets/LoginBox.html.twig
+++ b/src/Frontend/Themes/Bootstrap/Modules/Profiles/Layout/Widgets/LoginBox.html.twig
@@ -37,7 +37,7 @@
           <div class="form-group">
             <div class="col-sm-offset-2 col-sm-6">
               <input class="btn" type="submit" value="{{ 'lbl.Login'|trans|capitalize }}" />
-              <small><a href="{{ geturlforblock('Profiles':'ForgotPassword') }}" title="{{ 'msg.ForgotPassword'|trans }}">{{ 'msg.ForgotPassword'|trans }}</a></small>
+              <small><a href="{{ geturlforblock('Profiles', 'ForgotPassword') }}" title="{{ 'msg.ForgotPassword'|trans }}">{{ 'msg.ForgotPassword'|trans }}</a></small>
             </div>
           </div>
         </fieldset>


### PR DESCRIPTION
Use a comma instead of `:` as the separator in a twig function.

- Non critical bugfix

