### PR TITLE
Use symfony forms in mailmotor templates

### DIFF
--- a/src/Frontend/Themes/Bootstrap/Modules/Mailmotor/Layout/Templates/Subscribe.html.twig
+++ b/src/Frontend/Themes/Bootstrap/Modules/Mailmotor/Layout/Templates/Subscribe.html.twig
@@ -1,24 +1,36 @@
 {% import 'Core/Layout/Templates/Alerts.html.twig' as alerts %}
-<div id="mailmotorSubscribe">
-  {% if subscribeHasFormError %}
+
+<div id="mailmotorSubscribe" class="mailmotor">
+  {% if mailmotorSubscribeHasFormError %}
     {{ alerts.alert('danger', 'err.FormError'|trans) }}
   {% endif %}
-  {% if subscribeHasError %}
+  {% if mailmotorSubscribeHasError %}
     {{ alerts.alert('danger', 'err.SubscribeFailed'|trans) }}
   {% endif %}
-  {% if subscribeIsSuccess %}
-    {{ alerts.alert('success', 'msg.SubscribeSuccess'|trans) }}
+  {% if mailmotorSubscribeIsSuccess %}
+    {% if mailmotorSubscribeHasDoubleOptIn %}
+      {{ alerts.alert('success', 'msg.SubscribeSuccessForDoubleOptIn'|trans) }}
+    {% endif %}
+    {% if not mailmotorSubscribeHasDoubleOptIn %}
+      {{ alerts.alert('success', 'msg.SubscribeSuccess'|trans) }}
+    {% endif %}
   {% endif %}
 
-  {% if not subscribeHideForm %}
-    {% form subscribe %}
-      <label class="control-label" for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans|capitalize }}">*</abbr></label>
-      <div class="input-group{% if txtEmailError %} error{% endif %}">
-        {% form_field_error email %} {% form_field email %}
-        <div class="input-group-btn">
-          <input class="btn-primary btn" type="submit" name="send" value="{{ 'lbl.Send'|trans|capitalize }}" />
+  {% if not mailmotorSubscribeHideForm %}
+    <div class="well">
+      {{ form_start(form) }}
+      <div class="form-group">
+        <label for="{{ form.email.vars.id }}" class="control-label">{{ form.email.vars.label|trans|ucfirst }}</label>
+        <div class="input-group">
+          {{ form_widget(form.email) }}
+          <div class="input-group-btn">
+            <button type="submit" id="{{ form.subscribe.vars.id }}" class="btn btn-default">{{ form.subscribe.vars.label|trans }}</button>
+            {% do form.subscribe.setRendered %}
+          </div>
         </div>
       </div>
-    {% endform %}
+      {{ form_rest(form) }}
+      {{ form_end(form) }}
+    </div>
   {% endif %}
 </div>

--- a/src/Frontend/Themes/Bootstrap/Modules/Mailmotor/Layout/Templates/Unsubscribe.html.twig
+++ b/src/Frontend/Themes/Bootstrap/Modules/Mailmotor/Layout/Templates/Unsubscribe.html.twig
@@ -1,27 +1,32 @@
 {% import 'Core/Layout/Templates/Alerts.html.twig' as alerts %}
-<div id="mailmotorUnsubscribe">
-  {% if unsubscribeHasFormError %}
+<div id="mailmotorUnsubscribe" class="mailmotor">
+  {% if mailmotorUnsubscribeHasFormError %}
     {{ alerts.alert('danger', 'err.FormError'|trans) }}
   {% endif %}
-  {% if unsubscribeHasError %}
+  {% if mailmotorUnsubscribeHasError %}
     {{ alerts.alert('danger', 'err.UnsubscribeFailed'|trans) }}
   {% endif %}
-  {% if unsubscribeIsSuccess %}
+  {% if mailmotorUnsubscribeIsSuccess %}
     {{ alerts.alert('success', 'msg.UnsubscribeSuccess'|trans) }}
   {% endif %}
 
-  {% if not unsubscribeHideForm %}
-    {% form unsubscribe %}
-      <div class="control-group{% if txtEmailError %} error{% endif %}">
-        <label class="control-label" for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans|capitalize }}">*</abbr></label>
-        <div class="controls">
-          {% form_field_error email %} {% form_field email %}
+  <h3>{{ 'lbl.UnsubscribeFromNewsletter'|trans|capitalize }}</h3>
+
+  {% if not mailmotorUnsubscribeHideForm %}
+    <div class="well">
+      {{ form_start(form) }}
+      <div class="form-group">
+        <label for="{{ form.email.vars.id }}" class="control-label">{{ form.email.vars.label|trans|ucfirst }}</label>
+        <div class="input-group">
+          {{ form_widget(form.email) }}
+          <div class="input-group-btn">
+            <button type="submit" id="{{ form.unsubscribe.vars.id }}" class="btn btn-default">{{ form.unsubscribe.vars.label|trans }}</button>
+            {% do form.unsubscribe.setRendered %}
+          </div>
         </div>
       </div>
-
-      <div class="form-actions">
-        <input class="btn-primary btn" type="submit" name="send" value="{{ 'lbl.Send'|trans|capitalize }}" />
-      </div>
-    {% endform %}
+      {{ form_rest(form) }}
+      {{ form_end(form) }}
+    </div>
   {% endif %}
 </div>

--- a/src/Frontend/Themes/Bootstrap/Modules/Mailmotor/Layout/Widgets/Subscribe.html.twig
+++ b/src/Frontend/Themes/Bootstrap/Modules/Mailmotor/Layout/Widgets/Subscribe.html.twig
@@ -1,5 +1,5 @@
 <div id="mailmotorSubscribeWidget" class="well">
-  <form action="{{ geturlforblock('Mailmotor':'Subscribe') }}" method="post" class="form-inline">
+  <form action="{{ geturlforblock('Mailmotor','Subscribe') }}" method="post" class="form-inline">
     <input type="hidden" name="form_token" id="formToken" value="{{ formToken }}" />
     <input type="hidden" name="form" value="subscribe" />
     <label class="control-label" for="email">


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
Mailmotor templates were broken cause they didn't use symfony forms

