### PR TITLE
Fix last label in big paginations not showing

### DIFF
--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Pagination.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Pagination.html.twig
@@ -39,7 +39,7 @@
           {% for pagination in pagination.last %}
             <li>
               <a href="{{ pagination.url }}" rel="nofollow" title="{{ 'lbl.GoToPage'|trans|capitalize }}{{ pagination.label }}">
-                {{ pagination.last }}
+                {{ pagination.label }}
               </a>
             </li>
           {% endfor %}

--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Pagination.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Pagination.html.twig
@@ -38,7 +38,7 @@
           <li><span>…</span></li>
           {% for pagination in pagination.last %}
             <li>
-              <a href="{{ pagination.url }}" rel="nofollow" title="{{ 'lbl.GoToPage'|trans|capitalize }}{{ pagination.label }}">
+              <a href="{{ pagination.url }}" rel="nofollow" title="{{ 'lbl.GoToPage'|trans|capitalize }} {{ pagination.label }}">
                 {{ pagination.label }}
               </a>
             </li>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

if the pagination was more than 7 items the last number didn't show because a wrong template parameter was used

