### PR TITLE
WIP: Sentry integration logging

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -39,6 +39,7 @@ class AppKernel extends Kernel
             new \MailMotor\Bundle\MailChimpBundle\MailMotorMailChimpBundle(),
             new \MailMotor\Bundle\CampaignMonitorBundle\MailMotorCampaignMonitorBundle(),
             new \Liip\ImagineBundle\LiipImagineBundle(),
+            new \Sentry\SentryBundle\SentryBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'])) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -93,6 +93,9 @@ liip_imagine:
             filters:
                 thumbnail: { size : [1600, 500], mode : inbound }
 
+sentry:
+    dsn: "%sentry.dns%"
+
 services:
     form.type.editor:
         class: Backend\Form\Type\EditorType

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -21,3 +21,5 @@ parameters:
 
     action.group_tag:       <action-group-tag>
     action.rights_level:    <action-rights-level>
+
+    sentry.dns: ''

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "ramsey/uuid-doctrine": "^1.2",
         "liip/imagine-bundle": "^1.7",
         "swiftmailer/swiftmailer": "^5.4.6",
-        "google/recaptcha": "~1.1"
+        "google/recaptcha": "~1.1",
+        "sentry/sentry-symfony": "^0.8.1"
     },
     "require-dev": {
         "jdorn/sql-formatter": "1.2.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8151bb3b6ae798d00c73b5c8a536781d",
+    "content-hash": "cb2757e22c271eb92452a5487f54e699",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2487,6 +2487,130 @@
                 "uuid"
             ],
             "time": "2016-03-23T17:44:03+00:00"
+        },
+        {
+            "name": "sentry/sentry",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-php.git",
+                "reference": "f92d30467d9696606352aa06afeac0a60c4458ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/f92d30467d9696606352aa06afeac0a60c4458ef",
+                "reference": "f92d30467d9696606352aa06afeac0a60c4458ef",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": "^5.3|^7.0"
+            },
+            "conflict": {
+                "raven/raven": "*"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.8.0",
+                "monolog/monolog": "*",
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "suggest": {
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "immobiliare/sentry-php": "Fork that fixes support for PHP 5.2",
+                "monolog/monolog": "Automatically capture Monolog events as breadcrumbs"
+            },
+            "bin": [
+                "bin/sentry"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Raven_": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "David Cramer",
+                    "email": "dcramer@gmail.com"
+                }
+            ],
+            "description": "A PHP client for Sentry (http://getsentry.com)",
+            "homepage": "http://getsentry.com",
+            "keywords": [
+                "log",
+                "logging"
+            ],
+            "time": "2017-06-07T18:13:17+00:00"
+        },
+        {
+            "name": "sentry/sentry-symfony",
+            "version": "0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-symfony.git",
+                "reference": "1f3f2ca86d6ca8290fe27ea62272f338fabcc4c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-symfony/zipball/1f3f2ca86d6ca8290fe27ea62272f338fabcc4c9",
+                "reference": "1f3f2ca86d6ca8290fe27ea62272f338fabcc4c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sentry/sentry": ">=1.5.0",
+                "symfony/config": "^2.7|^3.0",
+                "symfony/console": "^2.7|^3.0",
+                "symfony/dependency-injection": "^2.7|^3.0",
+                "symfony/event-dispatcher": "^2.7|^3.0",
+                "symfony/http-kernel": "^2.7|^3.0",
+                "symfony/security-core": "^2.7|^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.8.0",
+                "phpunit/phpunit": "^4.6.6"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Sentry\\SentryBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Cramer",
+                    "email": "dcramer@gmail.com"
+                }
+            ],
+            "description": "Symfony integration for Sentry (http://getsentry.com)",
+            "homepage": "http://getsentry.com",
+            "keywords": [
+                "errors",
+                "logging",
+                "sentry",
+                "symfony"
+            ],
+            "time": "2017-07-27T09:17:54+00:00"
         },
         {
             "name": "simple-bus/doctrine-orm-bridge",


### PR DESCRIPTION
## Type

- Feature

## Pull request description

Errbit package used in [sumo-fork-class](https://github.com/sumocoders/Sumo-specific-Fork-stuff) currently doesn't work with Fork 5. Sentry is presented here as an alternative to Errbit.

