### PR TITLE
Add no-index automatically if host *.sumocoders.eu

### DIFF
--- a/src/Frontend/Core/Header/Header.php
+++ b/src/Frontend/Core/Header/Header.php
@@ -352,13 +352,6 @@ class Header extends KernelLoader
             $this->meta->addMetaData(MetaData::forName('robots', 'noindex, nofollow'), true);
         }
 
-        if (isset($_SERVER['HTTP_HOST']) && substr_count($_SERVER['HTTP_HOST'], '.sumocoders.eu') >= 1) {
-            $this->addMetaData(
-                array('name' => 'robots', 'content' => 'noindex, nofollow'),
-                true
-            );
-        }
-
         $this->template->addGlobal('meta', $this->meta);
         $this->template->addGlobal('metaCustom', $this->getMetaCustom());
         $this->cssFiles->parse($this->template, 'cssFiles');

--- a/src/Frontend/Core/Header/Header.php
+++ b/src/Frontend/Core/Header/Header.php
@@ -352,13 +352,6 @@ class Header extends KernelLoader
             $this->meta->addMetaData(MetaData::forName('robots', 'noindex, nofollow'), true);
         }
 
-        /**
-         * @remark only for SumoCoders
-         *
-         * Because ENV variables are not passed to CGI due to suExec.
-         * See http://wiki.dreamhost.com/Suexec#Apache_module_mod_env for more
-         * information.
-         */
         if (isset($_SERVER['HTTP_HOST']) && substr_count($_SERVER['HTTP_HOST'], '.sumocoders.eu') >= 1) {
             $this->addMetaData(
                 array('name' => 'robots', 'content' => 'noindex, nofollow'),

--- a/src/Frontend/Core/Header/Header.php
+++ b/src/Frontend/Core/Header/Header.php
@@ -352,6 +352,20 @@ class Header extends KernelLoader
             $this->meta->addMetaData(MetaData::forName('robots', 'noindex, nofollow'), true);
         }
 
+        /**
+         * @remark only for SumoCoders
+         *
+         * Because ENV variables are not passed to CGI due to suExec.
+         * See http://wiki.dreamhost.com/Suexec#Apache_module_mod_env for more
+         * information.
+         */
+        if (isset($_SERVER['HTTP_HOST']) && substr_count($_SERVER['HTTP_HOST'], '.sumocoders.eu') >= 1) {
+            $this->addMetaData(
+                array('name' => 'robots', 'content' => 'noindex, nofollow'),
+                true
+            );
+        }
+
         $this->template->addGlobal('meta', $this->meta);
         $this->template->addGlobal('metaCustom', $this->getMetaCustom());
         $this->cssFiles->parse($this->template, 'cssFiles');

--- a/src/Frontend/Core/Header/MetaCollection.php
+++ b/src/Frontend/Core/Header/MetaCollection.php
@@ -10,6 +10,17 @@ final class MetaCollection
     /** @var MetaLink[] */
     private $metaLinks = [];
 
+    public function __construct()
+    {
+        /* @remark Sumocoders staging websites should not be tracked */
+        if (isset($_SERVER['HTTP_HOST']) && substr_count($_SERVER['HTTP_HOST'], '.sumocoders.eu') >= 1) {
+            $this->addMetaData(
+                MetaData::forName('robots', 'noindex, nofollow'),
+                true
+            );
+        }
+    }
+
     public function addMetaData(MetaData $metaData, bool $overwrite = false): void
     {
         if ($overwrite || !array_key_exists($metaData->getUniqueKey(), $this->metaData)) {

--- a/src/Frontend/Core/Header/MetaCollection.php
+++ b/src/Frontend/Core/Header/MetaCollection.php
@@ -10,17 +10,6 @@ final class MetaCollection
     /** @var MetaLink[] */
     private $metaLinks = [];
 
-    public function __construct()
-    {
-        /* @remark Sumocoders staging websites should not be tracked */
-        if (isset($_SERVER['HTTP_HOST']) && substr_count($_SERVER['HTTP_HOST'], '.sumocoders.eu') >= 1) {
-            $this->addMetaData(
-                MetaData::forName('robots', 'noindex, nofollow'),
-                true
-            );
-        }
-    }
-
     public function addMetaData(MetaData $metaData, bool $overwrite = false): void
     {
         if ($overwrite || !array_key_exists($metaData->getUniqueKey(), $this->metaData)) {
@@ -46,6 +35,14 @@ final class MetaCollection
 
     public function __toString(): string
     {
+        /* @remark Sumocoders staging websites should not be tracked */
+        if (isset($_SERVER['HTTP_HOST']) && substr_count($_SERVER['HTTP_HOST'], '.sumocoders.eu') >= 1) {
+            $this->addMetaData(
+                MetaData::forName('robots', 'noindex, nofollow'),
+                true
+            );
+        }
+
         return implode("\n", $this->metaData) . "\n" . implode("\n", $this->metaLinks);
     }
 }


### PR DESCRIPTION
## Type

- Feature

## Resolves the following issues

https://app.activecollab.com/108877/reports/assignments?modal=Task-30843-860

## Pull request description

Websites with hostname like *.sumocoders.eu should have a no-index meta tag.

