### PR TITLE
Sentry integration

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -41,6 +41,10 @@ class AppKernel extends Kernel
             new \Liip\ImagineBundle\LiipImagineBundle(),
         ];
 
+        if ($this->getEnvironment() === 'prod') {
+            $bundles[] = new \Sentry\SentryBundle\SentryBundle();
+        }
+
         if (in_array($this->getEnvironment(), ['dev', 'test'])) {
             $bundles[] = new \Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new \Symfony\Bundle\DebugBundle\DebugBundle();

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: config.yml }
+
+# Sentry configuration
+sentry:
+  dsn: '%sentry.dsn%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -21,3 +21,5 @@ parameters:
 
     action.group_tag:       '<action-group-tag>'
     action.rights_level:    <action-rights-level>
+
+    sentry.dsn: ''

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "liip/imagine-bundle": "^1.7",
         "swiftmailer/swiftmailer": "^6.0",
         "google/recaptcha": "~1.1",
-        "spoon/library": "^3.0"
+        "spoon/library": "^3.0",
+        "sentry/sentry-symfony": "^0.8.2"
     },
     "require-dev": {
         "jdorn/sql-formatter": "1.2.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "29111fd1adeaf54648ad77c9d757b13a",
+    "content-hash": "8d75d0ebde451b1c241942242dfe2121",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2724,6 +2724,130 @@
                 "uuid"
             ],
             "time": "2017-07-18T16:21:14+00:00"
+        },
+        {
+            "name": "sentry/sentry",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-php.git",
+                "reference": "ed62ac351124a136f61b7ece7e0d172f4c56897b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/ed62ac351124a136f61b7ece7e0d172f4c56897b",
+                "reference": "ed62ac351124a136f61b7ece7e0d172f4c56897b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": "^5.3|^7.0"
+            },
+            "conflict": {
+                "raven/raven": "*"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.8.0",
+                "monolog/monolog": "*",
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "suggest": {
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "immobiliare/sentry-php": "Fork that fixes support for PHP 5.2",
+                "monolog/monolog": "Automatically capture Monolog events as breadcrumbs"
+            },
+            "bin": [
+                "bin/sentry"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Raven_": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "David Cramer",
+                    "email": "dcramer@gmail.com"
+                }
+            ],
+            "description": "A PHP client for Sentry (http://getsentry.com)",
+            "homepage": "http://getsentry.com",
+            "keywords": [
+                "log",
+                "logging"
+            ],
+            "time": "2017-08-02T16:38:25+00:00"
+        },
+        {
+            "name": "sentry/sentry-symfony",
+            "version": "0.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-symfony.git",
+                "reference": "c603aa354c8c3ffe4c39b1e80a82a0407bb3144b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-symfony/zipball/c603aa354c8c3ffe4c39b1e80a82a0407bb3144b",
+                "reference": "c603aa354c8c3ffe4c39b1e80a82a0407bb3144b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sentry/sentry": ">=1.5.0",
+                "symfony/config": "^2.7|^3.0",
+                "symfony/console": "^2.7|^3.0",
+                "symfony/dependency-injection": "^2.7|^3.0",
+                "symfony/event-dispatcher": "^2.7|^3.0",
+                "symfony/http-kernel": "^2.7|^3.0",
+                "symfony/security-core": "^2.7|^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.8.0",
+                "phpunit/phpunit": "^4.6.6"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Sentry\\SentryBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Cramer",
+                    "email": "dcramer@gmail.com"
+                }
+            ],
+            "description": "Symfony integration for Sentry (http://getsentry.com)",
+            "homepage": "http://getsentry.com",
+            "keywords": [
+                "errors",
+                "logging",
+                "sentry",
+                "symfony"
+            ],
+            "time": "2017-07-28T18:56:56+00:00"
         },
         {
             "name": "simple-bus/doctrine-orm-bridge",


### PR DESCRIPTION
## Type

- Feature

## Pull request description

Errbit package used in [sumo-fork-class](https://github.com/sumocoders/Sumo-specific-Fork-stuff) currently doesn't work with Fork 5. Sentry is presented here as an alternative to Errbit.
