### PR TITLE
Move capistrano log destination to var/

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -9,6 +9,6 @@ require 'capistrano/forkcms'
 require 'capistrano/sumo'
 require 'capistrano/deploytags'
 
-set :format_options, log_file: 'app/logs/capistrano.log'
+set :format_options, log_file: 'var/logs/capistrano.log'
 
 Dir.glob('app/config/capistrano/tasks/*.rake').each { |r| import r }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The Capistrano log file is being written to app/logs instead of var/logs as it is currently standard in Symfony 3.
