### PR TITLE
Add new data attributes to make cookiebar actions work agian

### DIFF
--- a/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Notifications.html.twig
+++ b/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Notifications.html.twig
@@ -13,14 +13,14 @@
 <a href="#main" class="sr-only">{$lblSkipToContent|ucfirst}</a>
 
 {% if not cookieBarHide %}
-  <div id="cookieBar" class="cookiebar alert alert-fullwidth">
+  <div id="cookie-bar" class="cookiebar alert alert-fullwidth">
     <button type="button" class="close" data-dismiss="alert">×</button>
     <div class="container">
       <div class="d-flex justify-content-between">
         <p class="mb-0"><strong>{{ 'lbl.Warning'|trans|ucfirst }}:</strong> {{ 'msg.Cookies'|trans|raw }}</p>
         <div class="buttons">
-          <a href="#" id="cookieBarAgree" class="btn btn-primary btn-sm">{{ 'lbl.IAgree'|trans|ucfirst }}</a>
-          <a href="#" id="cookieBarDisagree" class="btn btn-primary btn-sm">{{ 'lbl.IDisagree'|trans|ucfirst }}</a>
+          <a href="#" id="cookieBarAgree" data-role="cookie-bar-button" data-action="agree" class="btn btn-primary btn-sm">{{ 'lbl.IAgree'|trans|ucfirst }}</a>
+          <a href="#" id="cookieBarDisagree" data-role="cookie-bar-button" data-action="disagree" class="btn btn-primary btn-sm">{{ 'lbl.IDisagree'|trans|ucfirst }}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

Cookiebar actions do not work, cause they do not have the correct data attributes


