### PR TITLE
Move cookiebar buttons on new line on mobile

### DIFF
--- a/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Notifications.html.twig
+++ b/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Notifications.html.twig
@@ -16,7 +16,7 @@
   <div id="cookie-bar" class="cookiebar alert alert-fullwidth">
     <button type="button" class="close" data-dismiss="alert">×</button>
     <div class="container">
-      <div class="d-flex justify-content-between">
+      <div class="d-flex flex-column flex-lg-row justify-content-between">
         <p class="mb-0"><strong>{{ 'lbl.Warning'|trans|ucfirst }}:</strong> {{ 'msg.Cookies'|trans|raw }}</p>
         <div class="buttons">
           <a href="#" id="cookieBarAgree" data-role="cookie-bar-button" data-action="agree" class="btn btn-primary btn-sm">{{ 'lbl.IAgree'|trans|ucfirst }}</a>


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

Layout cookiebar mobile bad, text and buttons were really close to each other

