### PR TITLE
Enable monolog rotating file log mode.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -41,9 +41,10 @@ twig:
 monolog:
     handlers:
         main:
-            type:  stream
+            type:  rotating_file
             path:  "%site.path_www%/var/logs/%kernel.environment%.log"
             level: error
+            max_files: 10
         # swift:
         #     type:       swift_mailer
         #     from_email: %fork.debug_email%


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

This PR enables log rotation using Monolog. The log rotates every day and logs from previous days are kept to a maximum of 10 files.
