### PR TITLE
Change node engine version from 7 to 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "engines": {
-    "node": "^7.*"
+    "node": "^8.*"
   },
   "theme": "Bootstrap4",
   "standard": {


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
This PR changes the nodejs engine required version from 7 to 8.
