### PR TITLE
Remove sweetscroll and use our own scroll to method

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "simple-ajax-uploader": "^2.5.5",
     "slick-carousel": "^1.6.0",
     "standard": "^10.0.3",
-    "sweet-scroll": "^2.2.1",
     "webpack": "^3.5.4",
     "webpack-stream": "^4.0.0"
   },

--- a/src/Frontend/Themes/Bootstrap4/src/Js/Index.js
+++ b/src/Frontend/Themes/Bootstrap4/src/Js/Index.js
@@ -2,7 +2,7 @@
 import 'bootstrap/dist/js/bootstrap'
 
 /* Utilities imports */
-import SweetScroll from 'sweet-scroll'
+import { ScrollTo } from './Utilities/ScrollTo'
 import { Resize } from './Utilities/Resize'
 /* import {Fancybox} from './Utilities/Fancybox' */
 
@@ -11,7 +11,7 @@ import { Resize } from './Utilities/Resize'
 import { Pagination } from './Theme/Pagination'
 
 /* Renders */
-window.sweetscroll = new SweetScroll()
+window.scrollto = new ScrollTo()
 window.resizeFunction = new Resize()
 window.pagination = new Pagination()
 

--- a/src/Frontend/Themes/Bootstrap4/src/Js/Utilities/ScrollTo.js
+++ b/src/Frontend/Themes/Bootstrap4/src/Js/Utilities/ScrollTo.js
@@ -1,0 +1,29 @@
+export class ScrollTo {
+  constructor () {
+    this.events()
+  }
+
+  events () {
+    $(document).on('click', '[data-scroll]', $.proxy(this.scrollTo, this))
+  }
+
+  scrollTo (event) {
+    let $anchor = $(event.currentTarget)
+    let target = $anchor.attr('href')
+    let offset = 0
+
+    // If there is a custom offset
+    if ($anchor.data('offset')) {
+      offset = $anchor.data('offset')
+    }
+
+    /* check if we have an url, and if it is on the current page and the element exists disabled for nav-tabs */
+    if ($(target).length > 0) {
+      let $htmlBody = $('html, body')
+      $htmlBody.stop()
+      $htmlBody.animate({
+        scrollTop: $(target).offset().top - offset
+      }, 500)
+    }
+  }
+}


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
Fix blank page in chrome. After an update of chrome to v67, sweet scroll causes this issue.

