### PR TITLE
Make skip to content link visible on focus

### DIFF
--- a/src/Frontend/Themes/Bootstrap4/src/Layout/Sass/base/_base.scss
+++ b/src/Frontend/Themes/Bootstrap4/src/Layout/Sass/base/_base.scss
@@ -1,3 +1,18 @@
 img {
   max-width: 100%;
 }
+
+.skip-content {
+  height: 1px;
+  position: absolute;
+  left: 50%;
+  overflow: hidden;
+  width: 1px;
+  z-index: -1;
+
+  &:focus {
+    height: auto;
+    width: auto;
+    z-index: 10;
+  }
+}

--- a/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Notifications.html.twig
+++ b/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Notifications.html.twig
@@ -10,7 +10,7 @@
 {{ alerts.alert('danger', 'msg.OldBrowser'|trans, true, 'ie') }}
 <![endif]-->
 
-<a href="#main" class="sr-only">{{ 'lbl.SkipToContent'|trans|ucfirst }}</a>
+<a href="#main" class="skip-content">{{ 'lbl.SkipToContent'|trans|ucfirst }}</a>
 
 {% if not cookieBarHide %}
   <div id="cookie-bar" class="cookiebar alert alert-primary alert-fullwidth">


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Improve accessibility by make the skip to content link visible on focus.

