### PR TITLE
Re-add gulp build:theme task because it is used for deployment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -408,6 +408,10 @@ const buildTheme = gulp.series(
   )
 )
 
+gulp.task('build:theme', gulp.series(
+  buildTheme
+))
+
 gulp.task('serve:theme', function () {
   livereload.listen()
   gulp.watch(`${paths.src}/Js/**/*.js`, gulp.parallel('build:theme:webpack:generate-development-js'))


### PR DESCRIPTION
## Type
- Critical bugfix

## Resolves the following issues
Our deployment uses the gulp task `build:theme` which was removed by updating Gulp.

## Pull request description
Re-add `build:theme` gulp task.

