### PR TITLE
Update the base of the form layout to bs4

### DIFF
--- a/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/FormLayout.html.twig
+++ b/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/FormLayout.html.twig
@@ -1,4 +1,4 @@
-{% extends 'bootstrap_3_layout.html.twig' %}
+{% extends 'bootstrap_4_layout.html.twig' %}
 
 {%- block form_label -%}
   {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' control-label')|trim}) -%}


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
We were still using form layout from bootstrap 3, we are now using 4

