### PR TITLE
Put the error after the field on blog detail page

### DIFF
--- a/src/Frontend/Themes/Bootstrap4/Modules/Blog/Layout/Templates/Detail.html.twig
+++ b/src/Frontend/Themes/Bootstrap4/Modules/Blog/Layout/Templates/Detail.html.twig
@@ -124,22 +124,22 @@ variables that are available:
               <div class="form-group{% if txtMessageError %} has-danger{% endif %}">
                 <label class="form-control-label" for="message">{{ 'lbl.Message'|trans|ucfirst }}<abbr title="{{ 'lbl.RequiredField'|trans|ucfirst }}">*</abbr></label>
                 <div class="controls">
-                  {% form_field_error message %} {% form_field message %}
+                  {% form_field message %} {% form_field_error message %}
                 </div>
               </div>
             </div>
             <div class="col-sm-5">
               <div class="form-group{% if txtAuthorError %} has-danger{% endif %}">
                 <label class="form-control-label" for="author">{{ 'lbl.Name'|trans|ucfirst }}<abbr title="{{ 'lbl.RequiredField'|trans|ucfirst }}">*</abbr></label>
-                {% form_field_error author %} {% form_field author %}
+                {% form_field author %} {% form_field_error author %}
               </div>
               <div class="form-group{% if txtEmailError %} has-danger{% endif %}">
                 <label class="form-control-label" for="email">{{ 'lbl.Email'|trans|ucfirst }}<abbr title="{{ 'lbl.RequiredField'|trans|ucfirst }}">*</abbr></label>
-                {% form_field_error email %} {% form_field email %}
+                {% form_field email %} {% form_field_error email %}
               </div>
               <div class="form-group{% if txtWebsiteError %} has-danger{% endif %}">
                 <label class="form-control-label" for="website">{{ 'lbl.Website'|trans|ucfirst }}</label>
-                {% form_field_error website %} {% form_field website %}
+                {% form_field website %} {% form_field_error website %}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
Put the error after the form input field on the detail page of a blog item, so that it is the same as everywhere else in Fork.

