### PR TITLE
Make adding a timestamp in the php work

### DIFF
--- a/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Base.html.twig
+++ b/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Base.html.twig
@@ -127,7 +127,7 @@
   {% block footerScripts %}
   {# General Javascript #}
     {% for jsFile in jsFiles %}
-      <script src="{{ jsFile.file|raw }}"></script>
+      <script src="{{ jsFile|raw }}"></script>
     {% endfor %}
 
     <script src="{{ THEME_URL }}/Core/Js/bundle.js?t={{ LAST_MODIFIED_TIME }}"></script>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues
If the addTimestamp option was set true with the addJS function i wasn't working because of the way we rendered the script tags in the template