### PR TITLE
Fix session files cleanup errors on Debian

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -4,3 +4,7 @@ imports:
 # Sentry configuration
 sentry:
   dsn: '%sentry.dsn%'
+
+framework:
+    session:
+        gc_probability: null


### PR DESCRIPTION
Fixes SessionHandler::gc(): ps_files_cleanup_dir: opendir(/var/lib/php/sessions) failed: Permission denied (13)

## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Critical bugfix
- Non critical bugfix
- Enhancement
- Feature

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
