### PR TITLE
Use correct input group class

### DIFF
--- a/src/Frontend/Themes/Bootstrap4/Modules/Profiles/Layout/Templates/ForgotPassword.html.twig
+++ b/src/Frontend/Themes/Bootstrap4/Modules/Profiles/Layout/Templates/ForgotPassword.html.twig
@@ -12,9 +12,9 @@
       <label for="email">{{ 'lbl.Email'|trans|ucfirst }}<abbr title="{{ 'lbl.RequiredField'|trans|ucfirst }}">*</abbr></label>
       <div class="input-group{% if txtEmailError %} has-danger{% endif %}">
         {% form_field email %}
-        <span class="input-group-btn">
+        <div class="input-group-append">
           <input class="btn btn-primary" type="submit" value="{{ 'lbl.Send'|trans|ucfirst }}" />
-        </span>
+        </div>
       </div>
       {% form_field_error email %}
     {% endform %}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

The wrong class breaks the layout, `input-group-append` is what we now use with Bootstrap 4

