### PR TITLE
Increase memory for PHPStan

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ phpstan:
         - cp app/config/parameters.yml.gitlab app/config/parameters.yml
         - php composer.phar install --quiet --ignore-platform-reqs
     script:
-        - bin/phpstan analyze src
+        - php -d memory_limit=-1 bin/phpstan analyze src
     stage: code quality
     tags:
         - php71


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description

PHPStan requires more memory than 512MB which is set by default on our images.

At the same time there were a lot of job that exited with a 137 code. Which indicated our runners ran out of memory. After some digging around I think it was related to:

* https://gitlab.com/gitlab-org/gitlab-runner/issues/3816#note_149184430
* https://gitlab.com/gitlab-org/gitlab-runner/issues/3816#note_132190195

We were using `https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-2135-6-0-v20190801` hardcoded in our `/etc/gitlab/config.toml`. By replacing this with `https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/family/coreos-stable` our runners will use the latest stable release of CoreOS.
