### PR TITLE
Fix image in error template

### DIFF
--- a/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Error.html.twig
+++ b/src/Frontend/Themes/Bootstrap4/src/Layout/Templates/Error.html.twig
@@ -7,11 +7,7 @@
   </div>
 
   <div class="container">
-    <div class="row">
-      <div id="errorIcon">
-        <img src="{{ THEME_URL }}/apple-touch-icon.png" class="img-circle">
-      </div>
-    </div>
+    <img src="{{ THEME_URL }}/apple-touch-icon-180.png" class="mb-3">
     {% for block in positions.main %}
       {% if block.html %}
         {{ block.html|raw }}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

Unexisting image in error template

## Pull request description

Changes the image to one that is in the project and get rid of the incorrect divs arround is (row div but no col div).