### PR TITLE
Readd font awesome because it's use in the backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5379,6 +5379,12 @@
         }
       }
     },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
+      "dev": true
+    },
     "fontfacegen": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fontfacegen/-/fontfacegen-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "del": "^3.0.0",
     "fancybox": "^3.0.0",
     "fine-uploader": "^5.14.1",
+    "font-awesome": "^4.7.0",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-consolidate": "^0.2.0",


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Critical bugfix

## Pull request description

Font awesome 4 is still used in the backend so can't be removed yet
