### PR TITLE
Fix sticky footer to much whitespace

### DIFF
--- a/src/Frontend/Themes/Bootstrap4/src/Layout/Sass/components/_footer.scss
+++ b/src/Frontend/Themes/Bootstrap4/src/Layout/Sass/components/_footer.scss
@@ -10,6 +10,7 @@ body {
 
 #root {
   flex: 1 0 auto;
+  min-height: 1px;
 }
 
 footer {


### PR DESCRIPTION
Fix sticky footer to much whitespace caused by resized images in the content (in Internet Explorer)
