### PR TITLE
Add form-group class itself because bootstrap does not use it anymore…

### DIFF
--- a/src/Frontend/Themes/Bootstrap5/src/Layout/Sass/components/_forms.scss
+++ b/src/Frontend/Themes/Bootstrap5/src/Layout/Sass/components/_forms.scss
@@ -1,5 +1,4 @@
 .has-danger {
-
   .form-control-feedback,
   .form-control-label {
     color: theme-color("danger");
@@ -26,4 +25,8 @@ select.form-control[size] {
 .input-group .twitter-typeahead {
   float: none;
   width: auto;
+}
+
+.form-group {
+  margin-bottom: $spacer;
 }


### PR DESCRIPTION
`.form-group` zelf toevoegen want Bootstraps heeft het laten vallen, wat stom is.

Zij raden aan om utility class te gebruiken daarvoor, `mb-3`. Maar als je dan de margin groter of kleiner wilt maken moet je die class overal gaan vervangen. 1 algemene class lijkt mij dus nog steeds beter.