### PR TITLE
Fix boostrap5 theme for forms

### DIFF
--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/FormLayout.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/FormLayout.html.twig
@@ -1,4 +1,4 @@
-{% extends 'FormLayouts/bootstrap_5_layout.html.twig' %}
+{% extends 'Core/Layout/Templates/FormLayouts/bootstrap_5_layout.html.twig' %}
 
 {%- block form_label -%}
   {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' control-label')|trim}) -%}

--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/FormLayouts/bootstrap_5_layout.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/FormLayouts/bootstrap_5_layout.html.twig
@@ -263,7 +263,7 @@
         {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' col-form-label' )|trim}) -%}
       {%- endif -%}
     {%- else -%}
-      {%- set row_class = row_class|default(row_attr.class|default('')) -%}
+      {%- set row_class = row_class|default(attr.class|default('')) -%}
       {%- set label_attr = label_attr|merge({for: id}) -%}
       {%- if 'col-form-label' not in parent_label_class -%}
         {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ('input-group' in row_class ? ' input-group-text' : ' form-label') )|trim}) -%}
@@ -328,8 +328,8 @@
   {%- if help is not empty -%}
     {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
   {%- endif -%}
-  {%- set row_class = row_class|default(row_attr.class|default('mb-3')|trim) -%}
-  <{{ element|default('div') }}{% with {attr: row_attr|merge({class: row_class})} %}{{ block('attributes') }}{% endwith %}>
+  {%- set row_class = row_class|default(attr.class|default('mb-3')|trim) -%}
+  <{{ element|default('div') }}{% with {attr: attr|merge({class: row_class})} %}{{ block('attributes') }}{% endwith %}>
   {%- if 'form-floating' in row_class -%}
     {{- form_widget(form, widget_attr) -}}
     {{- form_label(form) -}}
@@ -337,13 +337,12 @@
     {{- form_label(form) -}}
     {{- form_widget(form, widget_attr) -}}
   {%- endif -%}
-  {{- form_help(form) -}}
   {{- form_errors(form) -}}
   </{{ element|default('div') }}>
 {%- endblock form_row %}
 
 {%- block button_row -%}
-  <div{% with {attr: row_attr|merge({class: row_attr.class|default('mb-3')|trim})} %}{{ block('attributes') }}{% endwith %}>
+  <div{% with {attr: attr|merge({class: attr.class|default('mb-3')|trim})} %}{{ block('attributes') }}{% endwith %}>
     {{- form_widget(form) -}}
   </div>
 {%- endblock button_row %}
@@ -357,18 +356,3 @@
     {%- endfor -%}
   {%- endif %}
 {%- endblock form_errors %}
-
-{# Help #}
-
-{%- block form_help -%}
-  {% set row_class = row_attr.class|default('') %}
-  {% set help_class = ' form-text' %}
-  {% if 'input-group' in row_class %}
-    {#- Hack to properly display help with input group -#}
-    {% set help_class = ' input-group-text' %}
-  {% endif %}
-  {%- if help is not empty -%}
-    {%- set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ help_class ~ ' mb-0')|trim}) -%}
-  {%- endif -%}
-  {{- parent() -}}
-{%- endblock form_help %}


### PR DESCRIPTION
New project, had error:
`Template "FormLayouts/bootstrap_5_layout.html.twig" is not defined.`

when was fixed, another:
`Unknown "form_help" function. Did you mean "form_rest", "form_end"?`

when fixed, another:
`The merge filter only works with arrays or "Traversable", got "NULL" as first argument in "Core/Layout/Templates/FormLayouts/bootstrap_5_layout.html.twig".`