### PR TITLE
Limit styles in CKEditor

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -436,7 +436,6 @@ jsBackend.ckeditor = {
     jsBackend.ckeditor.defaultConfig.language = jsBackend.data.get('editor.language')
 
     // content Css
-    jsBackend.ckeditor.defaultConfig.contentsCss.push('/src/Frontend/Core/Layout/Css/screen.css')
     if (jsBackend.data.get('theme.has_css')) jsBackend.ckeditor.defaultConfig.contentsCss.push('/src/Frontend/Themes/' + jsBackend.data.get('theme.theme') + '/Core/Layout/Css/screen.css')
     jsBackend.ckeditor.defaultConfig.contentsCss.push('/src/Frontend/Core/Layout/Css/editor_content.css')
     if (jsBackend.data.get('theme.has_editor_css')) jsBackend.ckeditor.defaultConfig.contentsCss.push('/src/Frontend/Themes/' + jsBackend.data.get('theme.theme') + '/Core/Layout/Css/editor_content.css')

--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -344,6 +344,8 @@ jsBackend.ckeditor = {
     // The CSS file(s) to be used to apply style to editor content.
     // It should reflect the CSS used in the target pages where the content is to be displayed.
     contentsCss: [],
+    // Skip some selectors: formelements
+    stylesheetParser_skipSelectors: /(^select\.|^textarea\.|^\.)/i,
 
     // buttons
     toolbar_Full: [


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Too many styles are shown in CKEditor:

* Removed default frontend fork style sheets from the list of stylesheets that should be parsed for styles
* Make sure `select` and `textarea` selectors are skipped