### PR TITLE
Add bootstrap 5 classes to formbuilder inputs

### DIFF
--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -168,6 +168,8 @@ class Form extends FrontendBaseWidget
                 $defaultValues = $field['settings']['default_values'] ?? null;
 
                 if ($field['type'] === 'dropdown') {
+                    $item['classname'] .= ' form-select';
+
                     // values and labels are the same
                     $values = array_combine($values, $values);
 
@@ -192,12 +194,14 @@ class Form extends FrontendBaseWidget
                     // get content
                     $item['html'] = $ddm->parse();
                 } elseif ($field['type'] === 'radiobutton') {
+                    $item['classname'] .= ' form-check-input';
                     // create element
                     $rbt = $this->form->addRadiobutton($item['name'], $values, $defaultValues, $item['classname']);
 
                     // get content
                     $item['html'] = $rbt->parse();
                 } elseif ($field['type'] === 'checkbox') {
+                    $item['classname'] .= ' form-check-input';
                     // reset
                     $newValues = [];
 

--- a/src/Frontend/Themes/Bootstrap/Modules/FormBuilder/Layout/Widgets/Form.html.twig
+++ b/src/Frontend/Themes/Bootstrap/Modules/FormBuilder/Layout/Widgets/Form.html.twig
@@ -56,9 +56,10 @@
                       {{ field.label|raw }}{% if field.required %}<abbr title="{{ 'lbl.RequiredField'|trans|ucfirst }}">*</abbr>{% endif %}
                     </p>
                     {% for checkbox in field.html %}
-                      <div class="checkbox">
-                        <label for="{{ checkbox.id|raw }}">
-                          {{ checkbox.field|raw }} {{ checkbox.label|raw }}
+                      <div class="form-check">
+                        {{ checkbox.field|raw }}
+                        <label for="{{ checkbox.id|raw }}" class="form-check-label">
+                          {{ checkbox.label|raw }}
                         </label>
                       </div>
                     {% endfor %}


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description

Add bootstrap 5 classes to the formbuilder inputs to make sure they are rendered correctly.
