### PR TITLE
Move privacy consent dialog out of notifications to bottom of page in…

### DIFF
--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Base.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Base.html.twig
@@ -115,6 +115,10 @@
     {% include 'Core/Layout/Templates/Footer.html.twig' %}
   {% endblock %}
 
+  {% block privacyConsentDialog %}
+    {% include "Core/Layout/Templates/PrivacyConsentDialog.html.twig" %}
+  {% endblock %}
+
   {# Site wide HTML #}
   {% block htmlFooter %}
     {{ siteHTMLFooter|raw }}

--- a/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Notifications.html.twig
+++ b/src/Frontend/Themes/Bootstrap/src/Layout/Templates/Notifications.html.twig
@@ -26,7 +26,3 @@
     </div>
   </div>
 {% endif %}
-
-{% block privacyConsentDialog %}
-  {% include "Core/Layout/Templates/PrivacyConsentDialog.html.twig" %}
-{% endblock %}


### PR DESCRIPTION
… Base.html.twig

## Type
- Enhancement

## Pull request description

Moves the privacy consent dialog to the bottom of the page, to prevent the privacy modal text showing up in google results.
