### PR TITLE
Fix name of opcache reset file for deployer

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -42,7 +42,7 @@ deny from env=stayout
     RewriteRule src/Backend/Core/Js/ckfinder/core/connector/php/connector\.php - [L]
 
     # allow the php-opcache-reset.php file
-    RewriteRule ^php-opcache-reset\.php - [L]
+    RewriteRule ^php-opcache_reset\.php - [L]
 
     # allow our root index.php
     RewriteRule ^index\.php$ - [L]


### PR DESCRIPTION
Allow the correct file in .htaccess.  
The name changed going from capistrano to deployer.

See: https://github.com/tijsverkoyen/deployer-sumo/blob/b07c4853a06909fcea4d6bc9ba25b740c0752689/recipe/opcache.php#L9

## Type

- Bugfix
