### PR TITLE
Add time to user template images to make unique filesnames

### DIFF
--- a/src/Backend/Modules/Pages/Ajax/UploadFile.php
+++ b/src/Backend/Modules/Pages/Ajax/UploadFile.php
@@ -118,7 +118,7 @@ class UploadFile extends AjaxAction
         }
 
         // convert the filename to url friendly version
-        $baseName = Uri::getUrl(pathinfo($fileName, PATHINFO_FILENAME));
+        $baseName = Uri::getUrl(pathinfo($fileName, PATHINFO_FILENAME)) . '_' . time();
         $extension = pathinfo($fileName, PATHINFO_EXTENSION);
         if (!in_array(strtolower($extension), self::ALLOWED_EXTENSIONS)) {
             throw new Exception('This is not an image.');


### PR DESCRIPTION
Internal link: https://app.activecollab.com/108877/reports/assignments?modal=Task-204045-62

Add time to filenames for user template images. So they have unique filenames and other user templates (with same image) don't break when you change an image to a different one.