### PR TITLE
Fix delete user template directory

### DIFF
--- a/src/Backend/Modules/Pages/Ajax/RemoveUploadedFile.php
+++ b/src/Backend/Modules/Pages/Ajax/RemoveUploadedFile.php
@@ -25,6 +25,12 @@ class RemoveUploadedFile extends AjaxAction
 
         $path = FRONTEND_FILES_PATH . '/Pages/' . $directory . '/' . $file;
 
+        if (!is_file($path)) {
+            $this->output(Response::HTTP_OK);
+
+            return;
+        }
+
         $filesystem = new Filesystem();
         if ($filesystem->exists($path)) {
             $filesystem->remove($path);

--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -970,7 +970,7 @@ jsBackend.pages.extras = {
           )
 
           // send a request to remove the old image if the old image doesn't have the same name
-          if (oldImage !== response.data) {
+          if (oldImage && oldImage !== response.data) {
             $.ajax({
               data: {
                 fork: {module: 'Pages', action: 'RemoveUploadedFile'},
@@ -1022,7 +1022,7 @@ jsBackend.pages.extras = {
           )
 
           // send a request to remove the old image if the old image doesn't have the same name
-          if (oldImage !== response.data) {
+          if (oldImage && oldImage !== response.data) {
             $.ajax({
               data: {
                 fork: {module: 'Pages', action: 'RemoveUploadedFile'},


### PR DESCRIPTION
Internal link: https://app.activecollab.com/108877/reports/assignments?modal=Task-208932-62

When there is no old image, the whole UserTemplate directory gets deleted