### PR TITLE
Update stylelintrc to support scss

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,6 +1,7 @@
 {
-  "extends": "stylelint-config-standard",
+  "extends": "stylelint-config-standard-scss",
   "rules": {
-    "at-rule-no-unknown": null
+    "at-rule-no-unknown": null,
+    "no-descending-specificity": null
   }
 }


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

Fixes issues with stylelint incorrectly parsing scss files

## Pull request description

Update .stylelintrc to use scss config and ignore no-descending-specificity rule (throws errors with nesting in scss that wil be solved on compile)