### PR TITLE
Fix no recipients formatter

### DIFF
--- a/src/Backend/Modules/FormBuilder/Engine/Model.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Model.php
@@ -289,11 +289,17 @@ class Model
      */
     public static function formatRecipients(string $string): string
     {
+        if ($string === '') {
+            return '';
+        }
+
+        $unserialized = @unserialize($string, ['allowed_classes' => false]);
+
         return implode(
             ', ',
             (array) array_map(
                 'htmlspecialchars',
-                @unserialize($string, ['allowed_classes' => false])
+                $unserialized
             )
         );
     }


### PR DESCRIPTION
## Summary by Sourcery

Improve the formatRecipients method by handling empty input early and reusing the unserialized data when formatting recipients.

Bug Fixes:
- Return an empty string for empty recipient input to prevent unnecessary unserialize calls and warnings

Enhancements:
- Cache the result of unserialize before processing to avoid repeated function calls