### PR TITLE
528-formbuilder-checkboxes-reset

### DIFF
--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -410,6 +410,18 @@ jsBackend.FormBuilder.Fields = {
                 data.data.field.settings.default_values = ''
               }
 
+              // Reset checkboxes
+              $('#textboxReplyTo').prop('checked', false)
+              $('#textboxMailmotor').prop('checked', false)
+              $('#textboxSendConfirmationMailTo').prop('checked', false)
+              $('#textboxRequired').prop('checked', false)
+              $('#textareaRequired').prop('checked', false)
+              $('#fileRequired').prop('checked', false)
+              $('#datetimeRequired').prop('checked', false)
+              $('#dropdownRequired').prop('checked', false)
+              $('#radiobuttonRequired').prop('checked', false)
+              $('#checkboxRequired').prop('checked', false)
+
               var html = ''
 
               // textbox edit


### PR DESCRIPTION
## Summary by Sourcery

Reset the checked state of various form builder checkboxes when resetting field default values to prevent stale selections

Bug Fixes:
- Clear checked state for ReplyTo checkbox
- Clear checked state for Mailmotor checkbox
- Clear checked state for SendConfirmationMailTo checkbox
- Clear checked state for 'required' checkboxes on all form field types