### PR TITLE
556 Fix undefined database when installing

### DIFF
--- a/app/config/config_install.yml
+++ b/app/config/config_install.yml
@@ -74,6 +74,7 @@ services:
             - "%database.port%"
         calls:
             - [ setDebug, [ "%kernel.debug%" ]]
+    SpoonDatabase: '@database'
 
     ForkCMS\Utility\Thumbnails:
         public: true


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Define the SpoonDatabase service alias to point to the database service in the install configuration to prevent undefined database errors.