### PR TITLE
550 Replace scrapbook with symfony cache

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -26,6 +26,9 @@ framework:
                 adapter: cache.app
                 public: true
                 default_lifetime: 3600
+            cache.pool:
+                adapter: cache.app
+                public: true
     mailer:
         dsn: '%mailer.dsn%'
     messenger:
@@ -158,27 +161,7 @@ services:
             - [ execute, [ 'SET sql_mode = REPLACE(@@SESSION.sql_mode, "ONLY_FULL_GROUP_BY", "")'] ]
             - [ setDebug, [ "%kernel.debug%" ]]
     SpoonDatabase: '@database'
-    cache.filesystem.adapter:
-        class: League\Flysystem\Adapter\Local
-        arguments:
-            - "%kernel.cache_dir%"
-    cache.filesystem.filesystem:
-        class: League\Flysystem\Filesystem
-        arguments:
-            - "@cache.filesystem.adapter"
-    cache.adapter:
-        class: MatthiasMullie\Scrapbook\Adapters\Flysystem
-        arguments:
-            - "@cache.filesystem.filesystem"
-    cache.buffer:
-        class: MatthiasMullie\Scrapbook\Buffered\BufferedStore
-        arguments:
-            - "@cache.adapter"
-    cache.pool:
-        class: MatthiasMullie\Scrapbook\Psr6\Pool
-        public: true
-        arguments:
-            - "@cache.buffer"
+
     cache.backend_navigation:
         class: Backend\Core\Engine\NavigationCache
         public: true

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "mailmotor/campaignmonitor-bundle": "^3.0",
         "mailmotor/mailchimp-bundle": "^4.0",
         "mailmotor/mailmotor-bundle": "^4.0",
-        "matthiasmullie/scrapbook": "^1.3",
         "pimple/pimple": "^3.2",
         "spoon/library": "^4.0",
         "symfony/monolog-bundle": "^3.1",
@@ -57,7 +56,8 @@
         "twig/cssinliner-extra": "^3.23",
         "twig/string-extra": "^3.23",
         "twig/inky-extra": "^3.23",
-        "symfony/uid": "^5.4"
+        "symfony/uid": "^5.4",
+        "symfony/cache": "^5.4"
     },
     "require-dev": {
         "jdorn/sql-formatter": "1.2.17",

--- a/src/Common/Tests/ModulesSettingsTest.php
+++ b/src/Common/Tests/ModulesSettingsTest.php
@@ -3,10 +3,9 @@
 namespace Common\Tests;
 
 use Common\ModulesSettings;
-use MatthiasMullie\Scrapbook\Adapters\MemoryStore;
-use MatthiasMullie\Scrapbook\Psr6\Pool;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Tests for our module settings
@@ -17,7 +16,7 @@ class ModulesSettingsTest extends TestCase
     {
         $modulesSettings = new ModulesSettings(
             $this->getDatabaseMock(),
-            new Pool(new MemoryStore())
+            new ArrayAdapter()
         );
 
         $modulesSettings->get('Core', 'theme', 'Fork');
@@ -28,7 +27,7 @@ class ModulesSettingsTest extends TestCase
     {
         $modulesSettings = new ModulesSettings(
             $this->getDatabaseMock(),
-            new Pool(new MemoryStore())
+            new ArrayAdapter()
         );
 
         self::assertEquals(
@@ -45,7 +44,7 @@ class ModulesSettingsTest extends TestCase
     {
         $modulesSettings = new ModulesSettings(
             $this->getDatabaseMock(),
-            new Pool(new MemoryStore())
+            new ArrayAdapter()
         );
 
         self::assertEquals(
@@ -58,7 +57,7 @@ class ModulesSettingsTest extends TestCase
     {
         $modulesSettings = new ModulesSettings(
             $this->getDatabaseMock(),
-            new Pool(new MemoryStore())
+            new ArrayAdapter()
         );
 
         self::assertEquals(


### PR DESCRIPTION
## Summary by Sourcery

Replace the custom Scrapbook-based caching setup with Symfony’s native cache component across configuration, tests, and dependencies.

Enhancements:
- Configure a Symfony cache pool service using the framework cache.app adapter for application-wide caching.
- Update module settings tests to use Symfony's ArrayAdapter cache implementation instead of Scrapbook classes.

Build:
- Remove the matthiasmullie/scrapbook dependency and add symfony/cache to composer requirements.