### PR TITLE
DX: Type hint kernel get service

### DIFF
--- a/app/KernelLoader.php
+++ b/app/KernelLoader.php
@@ -28,9 +28,10 @@ class KernelLoader
     /**
      * Gets a service by id.
      *
-     * @param string $reference The service id
+     * @template Service
+     * @param string|class-string<Service> $reference The service id
      *
-     * @return mixed The service
+     * @return mixed|Service The service
      */
     public function get(string $reference)
     {


### PR DESCRIPTION
Useful when doing: $this->get(Service::class)

## Summary by Sourcery

Enhancements:
- Refine the `get` method PHPDoc to support generic service type inference when retrieving services by class name.