### PR TITLE
561: Replace SpoonDate

### DIFF
--- a/src/Backend/Core/Engine/DataGridFunctions.php
+++ b/src/Backend/Core/Engine/DataGridFunctions.php
@@ -3,8 +3,9 @@
 namespace Backend\Core\Engine;
 
 use Backend\Core\Engine\Model as BackendModel;
+use Backend\Core\Language\Language;
 use Backend\Core\Language\Language as BackendLanguage;
-use SpoonDate;
+use IntlDateFormatter;
 use function Symfony\Component\String\s;
 
 /**
@@ -70,9 +71,16 @@ class DataGridFunctions
             return '';
         }
 
-        $format = 'j F Y';
+        $date = new IntlDateFormatter(
+            BackendLanguage::getInterfaceLanguage(),
+            IntlDateFormatter::NONE,
+            IntlDateFormatter::NONE,
+            null,
+            null,
+            'd MMMM yyyy'
+        )->format($timestamp);
 
-        return SpoonDate::getDate($format, $timestamp, BackendLanguage::getInterfaceLanguage());
+        return $date;
     }
 
     /**
@@ -89,9 +97,17 @@ class DataGridFunctions
             return '';
         }
 
-        $format = 'j F Y H:i';
 
-        return SpoonDate::getDate($format, $timestamp, BackendLanguage::getInterfaceLanguage());
+        $date = new IntlDateFormatter(
+            BackendLanguage::getInterfaceLanguage(),
+            IntlDateFormatter::NONE,
+            IntlDateFormatter::NONE,
+            null,
+            null,
+            'd MMMM yyyy HH:mm'
+        )->format($timestamp);
+
+        return $date;
     }
 
     /**
@@ -108,9 +124,17 @@ class DataGridFunctions
             return '';
         }
 
-        $format = 'H:i';
 
-        return SpoonDate::getDate($format, $timestamp, BackendLanguage::getInterfaceLanguage());
+        $date = new IntlDateFormatter(
+            BackendLanguage::getInterfaceLanguage(),
+            IntlDateFormatter::NONE,
+            IntlDateFormatter::NONE,
+            null,
+            null,
+            'HH:mm'
+        )->format($timestamp);
+
+        return $date;
     }
 
     /**
@@ -122,15 +146,76 @@ class DataGridFunctions
      */
     public static function getTimeAgo(int $timestamp): string
     {
-        // get user setting for long dates
-        $format = 'j F Y H:i';
+        if ($timestamp === 0) {
+            return '';
+        }
 
-        // get the time ago as a string
-        $timeAgo = SpoonDate::getTimeAgo($timestamp, BackendLanguage::getInterfaceLanguage(), $format);
+        $locale = BackendLanguage::getInterfaceLanguage();
+
+        $dateTimeFormatter = new IntlDateFormatter(
+            $locale,
+            IntlDateFormatter::NONE,
+            IntlDateFormatter::NONE,
+            null,
+            null,
+            'yyyy-MM-dd HH:mm:ss'
+        );
+
+        $titleFormatter = new IntlDateFormatter(
+            $locale,
+            IntlDateFormatter::NONE,
+            IntlDateFormatter::NONE,
+            null,
+            null,
+            'd MMMM yyyy HH:mm'
+        );
+
+        $diff = abs(time() - $timestamp);
+
+        $seconds = (int) $diff;
+        $minutes = (int) floor($seconds / 60);
+        $hours   = (int) floor($seconds / 3600);
+        $days    = (int) floor($seconds / 86400);
+        $months  = (int) floor($seconds / (30 * 86400));
+        $years   = (int) floor($seconds / (365 * 86400));
+
+        if ($years > 0) {
+            $count = $years;
+            $keySingular = 'TimeAgoYearSingular';
+            $keyPlural   = 'TimeAgoYearPlural';
+        } elseif ($months > 0) {
+            $count = $months;
+            $keySingular = 'TimeAgoMonthSingular';
+            $keyPlural   = 'TimeAgoMonthPlural';
+        } elseif ($days > 0) {
+            $count = $days;
+            $keySingular = 'TimeAgoDaySingular';
+            $keyPlural   = 'TimeAgoDayPlural';
+        } elseif ($hours > 0) {
+            $count = $hours;
+            $keySingular = 'TimeAgoHourSingular';
+            $keyPlural   = 'TimeAgoHourPlural';
+        } elseif ($minutes > 0) {
+            $count = $minutes;
+            $keySingular = 'TimeAgoMinuteSingular';
+            $keyPlural   = 'TimeAgoMinutePlural';
+        } else {
+            $count = $seconds;
+            $keySingular = 'TimeAgoSecondSingular';
+            $keyPlural   = 'TimeAgoSecondPlural';
+        }
+
+        if ($count <= 0) {
+            return Language::lbl('TimeAgoEmpty');
+        }
+
+        $timeAgo = $count === 1
+            ? Language::lbl($keySingular)
+            : Language::lblWithParameters($keyPlural, [$count]);
 
         return '<time tabindex="0" data-toggle="tooltip" datetime="'
-               . SpoonDate::getDate('Y-m-d H:i:s', $timestamp)
-               . '" title="' . SpoonDate::getDate($format, $timestamp, BackendLanguage::getInterfaceLanguage())
+               . $dateTimeFormatter->format($timestamp)
+               . '" title="' . $titleFormatter->format($timestamp)
                . '">' . $timeAgo . '</time>';
     }
 

--- a/src/Backend/Core/Language/Language.php
+++ b/src/Backend/Core/Language/Language.php
@@ -301,4 +301,64 @@ class Language
     {
         return in_array($language, self::getActiveLanguages(), true);
     }
+
+    /**
+     * Get a label with parameters
+     *
+     * @param string $key
+     * @param array  $parameters
+     * @param bool   $fallback
+     *
+     * @return string
+     */
+    public static function lblWithParameters(string $key, array $parameters = [], bool $fallback = true): string
+    {
+        $label = self::getLabel($key, $fallback);
+
+        if ($parameters === []) {
+            return $label;
+        }
+
+        return vsprintf($label, $parameters);
+    }
+
+    /**
+     * Get a message with parameters
+     *
+     * @param string $key
+     * @param array  $parameters
+     * @param bool   $fallback
+     *
+     * @return string
+     */
+    public static function msgWithParameters(string $key, array $parameters = [], bool $fallback = true): string
+    {
+        $message = self::getMessage($key, $fallback);
+
+        if ($parameters === []) {
+            return $message;
+        }
+
+        return vsprintf($message, $parameters);
+    }
+
+    /**
+     * Get an error with parameters
+     *
+     * @param string $key
+     * @param array  $parameters
+     * @param bool   $fallback
+     *
+     * @return string
+     */
+    public static function errWithParameters(string $key, array $parameters = [], bool $fallback = true): string
+    {
+        $error = self::getError($key, $fallback);
+
+        if ($parameters === []) {
+            return $error;
+        }
+
+        return vsprintf($error, $parameters);
+    }
 }

--- a/src/Backend/Modules/Faq/Engine/Model.php
+++ b/src/Backend/Modules/Faq/Engine/Model.php
@@ -81,7 +81,7 @@ class Model
     {
         BackendModel::getContainer()->get('database')->update(
             'faq_feedback',
-            ['processed' => true, 'edited_on' => \SpoonDate::getDate('Y-m-d H:i:s')],
+            ['processed' => true, 'edited_on' => date('Y-m-d H:i:s')],
             'id = ?',
             $itemId
         );

--- a/src/Backend/Modules/FormBuilder/Actions/ExportData.php
+++ b/src/Backend/Modules/FormBuilder/Actions/ExportData.php
@@ -9,6 +9,7 @@ use Backend\Core\Engine\Model as BackendModel;
 use Backend\Modules\FormBuilder\Engine\Model as BackendFormBuilderModel;
 use Common\Exception\RedirectException;
 use ForkCMS\Utility\Csv\Writer;
+use IntlDateFormatter;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use function Symfony\Component\String\s;
 
@@ -186,12 +187,17 @@ class ExportData extends BackendBaseAction
         foreach ($records as $row) {
             // first row of a submission
             if (!isset($data[$row['data_id']])) {
+                $date = new IntlDateFormatter(
+                    BL::getWorkingLanguage(),
+                    IntlDateFormatter::NONE,
+                    IntlDateFormatter::NONE,
+                    null,
+                    null,
+                    'yyyy-MM-dd HH:mm:ss'
+                )->format($row['sent_on']);
+
                 $data[$row['data_id']][$lblSessionId] = $row['session_id'];
-                $data[$row['data_id']][$lblSentOn] = \SpoonDate::getDate(
-                    'Y-m-d H:i:s',
-                    $row['sent_on'],
-                    BL::getWorkingLanguage()
-                );
+                $data[$row['data_id']][$lblSentOn] = $date;
             }
 
             // value is serialized

--- a/src/Frontend/Core/Engine/Rss.php
+++ b/src/Frontend/Core/Engine/Rss.php
@@ -37,7 +37,7 @@ class Rss extends \SpoonFeedRSS
 
         // set feed properties
         $this->setLanguage(LANGUAGE);
-        $this->setCopyright(\SpoonDate::getDate('Y') . ' ' . $siteTitle);
+        $this->setCopyright(date('Y') . ' ' . $siteTitle);
         $this->setGenerator($siteTitle);
         $this->setImage(SITE_URL . FRONTEND_CORE_URL . '/Layout/images/rss_image.png', $title, $link);
 

--- a/src/Frontend/Modules/Blog/Actions/Archive.php
+++ b/src/Frontend/Modules/Blog/Actions/Archive.php
@@ -9,6 +9,7 @@ use Frontend\Core\Engine\Navigation;
 use Frontend\Core\Language\Language as FL;
 use Frontend\Core\Engine\Navigation as FrontendNavigation;
 use Frontend\Modules\Blog\Engine\Model as FrontendBlogModel;
+use IntlDateFormatter;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use function Symfony\Component\String\s;
@@ -170,8 +171,16 @@ class Archive extends FrontendBaseBlock
         $this->header->setPageTitle(s(FL::lbl('Archive'))->title()->toString());
         $this->header->setPageTitle($this->startDate->format('Y'));
         if ($this->hasMonth) {
+            $date = new IntlDateFormatter(
+                LANGUAGE,
+                IntlDateFormatter::NONE,
+                IntlDateFormatter::NONE,
+                null,
+                null,
+                'MMMM'
+            )->format($this->startDate->getTimestamp());
             $this->header->setPageTitle(
-                \SpoonDate::getDate('F', $this->startDate->getTimestamp(), LANGUAGE)
+                $date
             );
         }
     }
@@ -181,12 +190,16 @@ class Archive extends FrontendBaseBlock
         $this->breadcrumb->addElement(s(FL::lbl('Archive'))->title()->toString());
         $this->breadcrumb->addElement($this->startDate->format('Y'));
         if ($this->hasMonth) {
+            $date = new IntlDateFormatter(
+                LANGUAGE,
+                IntlDateFormatter::NONE,
+                IntlDateFormatter::NONE,
+                null,
+                null,
+                'MMMM'
+            )->format($this->startDate->getTimestamp());
             $this->breadcrumb->addElement(
-                \SpoonDate::getDate(
-                    'F',
-                    $this->startDate->getTimestamp(),
-                    LANGUAGE
-                )
+                $date
             );
         }
     }


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description

Replaces SpoonDate with IntlDateFormatter to format dates and timestamps where language is used, replace by date where language does not matter.

## Summary by Sourcery

Replace legacy SpoonDate usage with IntlDateFormatter-based date handling and add helper methods for parameterized translations.

Enhancements:
- Migrate backend and frontend date and time formatting from SpoonDate to IntlDateFormatter in grids, blog archive titles, breadcrumbs, form exports, and RSS metadata.
- Introduce Language helper methods to fetch labels, messages, and errors with parameter substitution.
- Improve the time-ago rendering logic to use localized IntlDateFormatter output and translation keys for singular and plural time units.