### PR TITLE
560: flush in repository

### DIFF
--- a/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/CopyContentBlocksToOtherLocaleHandler.php
+++ b/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/CopyContentBlocksToOtherLocaleHandler.php
@@ -16,7 +16,6 @@ final readonly class CopyContentBlocksToOtherLocaleHandler
 {
     public function __construct(
         private ContentBlockRepository $contentBlockRepository,
-        private EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -41,8 +40,6 @@ final readonly class CopyContentBlocksToOtherLocaleHandler
             },
             $contentBlocksToCopy
         );
-
-        $this->entityManager->flush();
     }
 
     private function getContentBlocksToCopy(Locale $locale): array

--- a/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/CreateContentBlockHandler.php
+++ b/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/CreateContentBlockHandler.php
@@ -14,7 +14,6 @@ final readonly class CreateContentBlockHandler
 {
     public function __construct(
         private ContentBlockRepository $contentBlockRepository,
-        private EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -27,8 +26,6 @@ final readonly class CreateContentBlockHandler
         $this->contentBlockRepository->add($contentBlock);
 
         $createContentBlock->setContentBlockEntity($contentBlock);
-
-        $this->entityManager->flush();
     }
 
     private function getNewExtraId(): int

--- a/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/DeleteContentBlockHandler.php
+++ b/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/DeleteContentBlockHandler.php
@@ -12,7 +12,6 @@ final readonly class DeleteContentBlockHandler
 {
     public function __construct(
         private ContentBlockRepository $contentBlockRepository,
-        private EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -24,7 +23,5 @@ final readonly class DeleteContentBlockHandler
         );
 
         Model::deleteExtraById($deleteContentBlock->contentBlock->getExtraId());
-
-        $this->entityManager->flush();
     }
 }

--- a/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/UpdateContentBlockHandler.php
+++ b/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/UpdateContentBlockHandler.php
@@ -12,7 +12,6 @@ final readonly class UpdateContentBlockHandler
 {
     public function __construct(
         private ContentBlockRepository $contentBlockRepository,
-        private EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -22,7 +21,5 @@ final readonly class UpdateContentBlockHandler
         $this->contentBlockRepository->add($contentBlock);
 
         $updateContentBlock->setContentBlockEntity($contentBlock);
-
-        $this->entityManager->flush();
     }
 }

--- a/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/ContentBlockRepository.php
+++ b/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/ContentBlockRepository.php
@@ -20,8 +20,8 @@ class ContentBlockRepository extends EntityRepository
             );
         }
 
-        // We don't flush here, see http://disq.us/p/okjc6b
         $this->getEntityManager()->persist($contentBlock);
+        $this->save();
     }
 
     public function getNextIdForLanguage(Locale $locale): int
@@ -72,12 +72,18 @@ class ContentBlockRepository extends EntityRepository
 
     public function removeByIdAndLocale($id, Locale $locale): void
     {
-        // We don't flush here, see http://disq.us/p/okjc6b
         array_map(
             function (ContentBlock $contentBlock): void {
                 $this->getEntityManager()->remove($contentBlock);
             },
             (array) $this->findBy(['id' => $id, 'locale' => $locale])
         );
+
+        $this->save();
+    }
+
+    public function save(): void
+    {
+        $this->getEntityManager()->flush();
     }
 }

--- a/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/Command/CreateMediaGalleryHandler.php
+++ b/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/Command/CreateMediaGalleryHandler.php
@@ -12,7 +12,6 @@ final readonly class CreateMediaGalleryHandler
 {
     public function __construct(
         private MediaGalleryRepository $mediaGalleryRepository,
-        private EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -23,7 +22,5 @@ final readonly class CreateMediaGalleryHandler
 
         // We redefine the mediaGallery, so we can use it in an action
         $createMediaGallery->setMediaGalleryEntity($mediaGallery);
-
-        $this->entityManager->flush();
     }
 }

--- a/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/Command/DeleteMediaGalleryHandler.php
+++ b/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/Command/DeleteMediaGalleryHandler.php
@@ -15,7 +15,6 @@ final readonly class DeleteMediaGalleryHandler
     public function __construct(
         private MediaGalleryRepository $mediaGalleryRepository,
         private MediaItemRepository $mediaItemRepository,
-        private EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -34,7 +33,5 @@ final readonly class DeleteMediaGalleryHandler
         }
 
         $this->mediaGalleryRepository->remove($deleteMediaGallery->mediaGallery);
-
-        $this->entityManager->flush();
     }
 }

--- a/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/Command/UpdateMediaGalleryHandler.php
+++ b/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/Command/UpdateMediaGalleryHandler.php
@@ -3,6 +3,7 @@
 namespace Backend\Modules\MediaGalleries\Domain\MediaGallery\Command;
 
 use Backend\Modules\MediaGalleries\Domain\MediaGallery\MediaGallery;
+use Backend\Modules\MediaGalleries\Domain\MediaGallery\MediaGalleryRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -10,7 +11,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 final readonly class UpdateMediaGalleryHandler
 {
     public function __construct(
-        private EntityManagerInterface $entityManager,
+        private MediaGalleryRepository $mediaGalleryRepository,
     ) {
     }
 
@@ -19,6 +20,6 @@ final readonly class UpdateMediaGalleryHandler
         // We redefine the mediaGallery, so we can use it in an action
         $updateMediaGallery->setMediaGalleryEntity(MediaGallery::fromDataTransferObject($updateMediaGallery));
 
-        $this->entityManager->flush();
+        $this->mediaGalleryRepository->save();
     }
 }

--- a/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/MediaGalleryRepository.php
+++ b/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/MediaGalleryRepository.php
@@ -16,6 +16,7 @@ final class MediaGalleryRepository extends EntityRepository
     public function add(MediaGallery $mediaGallery): void
     {
         $this->getEntityManager()->persist($mediaGallery);
+        $this->save();
     }
 
     public function existsByTitle(string $title, ?string $ignoreMediaGalleryId = null): bool
@@ -47,5 +48,11 @@ final class MediaGalleryRepository extends EntityRepository
     public function remove(MediaGallery $mediaGallery): void
     {
         $this->getEntityManager()->remove($mediaGallery);
+        $this->save();
+    }
+
+    public function save(): void
+    {
+        $this->getEntityManager()->flush();
     }
 }

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/Command/CreateMediaFolderHandler.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/Command/CreateMediaFolderHandler.php
@@ -12,7 +12,6 @@ final readonly class CreateMediaFolderHandler
 {
     public function __construct(
         private MediaFolderRepository $mediaFolderRepository,
-        private EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -24,7 +23,5 @@ final readonly class CreateMediaFolderHandler
 
         // We redefine the MediaFolder, so we can use it in an action
         $createMediaFolder->setMediaFolderEntity($mediaFolder);
-
-        $this->entityManager->flush();
     }
 }

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/Command/DeleteMediaFolderHandler.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/Command/DeleteMediaFolderHandler.php
@@ -20,7 +20,5 @@ final readonly class DeleteMediaFolderHandler
         $mediaFolder = $deleteMediaFolder->mediaFolder;
 
         $this->mediaFolderRepository->remove($mediaFolder);
-
-        $this->entityManager->flush();
     }
 }

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/Command/UpdateMediaFolderHandler.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/Command/UpdateMediaFolderHandler.php
@@ -3,6 +3,7 @@
 namespace Backend\Modules\MediaLibrary\Domain\MediaFolder\Command;
 
 use Backend\Modules\MediaLibrary\Domain\MediaFolder\MediaFolder;
+use Backend\Modules\MediaLibrary\Domain\MediaFolder\MediaFolderRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -10,7 +11,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 final readonly class UpdateMediaFolderHandler
 {
     public function __construct(
-        private EntityManagerInterface $entityManager,
+        private MediaFolderRepository $mediaFolderRepository,
     ) {
     }
 
@@ -19,6 +20,6 @@ final readonly class UpdateMediaFolderHandler
         // We redefine the MediaFolder, so we can use it in an action
         $updateMediaFolder->setMediaFolderEntity(MediaFolder::fromDataTransferObject($updateMediaFolder));
 
-        $this->entityManager->flush();
+        $this->mediaFolderRepository->save();
     }
 }

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolderRepository.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolderRepository.php
@@ -10,8 +10,8 @@ final class MediaFolderRepository extends EntityRepository
 {
     public function add(MediaFolder $mediaFolder): void
     {
-        // We don't flush here, see http://disq.us/p/okjc6b
         $this->getEntityManager()->persist($mediaFolder);
+        $this->save();
     }
 
     private function bumpFolderCount(int $folderId, array &$counts): void
@@ -82,7 +82,12 @@ final class MediaFolderRepository extends EntityRepository
 
     public function remove(MediaFolder $mediaFolder): void
     {
-        // We don't flush here, see http://disq.us/p/okjc6b
         $this->getEntityManager()->remove($mediaFolder);
+        $this->save();
+    }
+
+    public function save(): void
+    {
+        $this->getEntityManager()->flush();
     }
 }


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description

Fish inside repository instead of inside the message handlers for ContentBlock, MediaGallery and MediaLibrary modules

## Summary by Sourcery

Move transaction flushing responsibility from message handlers into the domain repositories for content blocks, media galleries, and media folders.

Enhancements:
- Introduce repository-level save() methods that flush the entity manager for content blocks, media galleries, and media folders.
- Update command handlers to depend on repositories instead of the generic entity manager and to stop calling flush() directly.