### PR TITLE
Fix tags pagination not showing all tags

### DIFF
--- a/src/Backend/Modules/Tags/Installer/Data/install.sql
+++ b/src/Backend/Modules/Tags/Installer/Data/install.sql
@@ -5,4 +5,5 @@ CREATE TABLE IF NOT EXISTS `tags` (
   `number` int(11) NOT NULL,
   `url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`)
+  KEY `idx_number` (`number`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1 ;


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Fix tags pagination not showing all tags when ordered by number.

## Summary by Sourcery

Enhancements:
- Add an index on the tags table number column to improve ordering and pagination performance.