### PR TITLE
Add sitemap.xml generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ docker-compose.override.yml
 
 # Twig CS Fixer cache
 /.twig-cs-fixer.cache
+
+# Generated sitemap
+/sitemap.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Fork CMS — an open-source PHP CMS built on Symfony 5.4 (LTS), with a custom module system predating full Symfony bundle conventions. PHP ^8.5, Doctrine ORM, Twig templates.
+
+## Commands
+
+### PHP dependencies & app bootstrap
+```bash
+composer install                      # installs deps, then runs auto-scripts (cache:clear, cache:warmup)
+php bin/console forkcms:cache:clear   # ForkCMS-specific cache clear (module/theme metadata)
+php bin/console cache:clear --no-warmup
+php bin/console cache:warmup
+```
+
+### Tests (PHPUnit via Symfony's phpunit-bridge)
+```bash
+composer test                                   # runs ./bin/simple-phpunit (all suites)
+php bin/simple-phpunit --testsuite=unit
+php bin/simple-phpunit --testsuite=functional
+php bin/simple-phpunit --testsuite=installer
+php bin/simple-phpunit --filter testMethodName
+php bin/simple-phpunit src/Backend/Modules/Blog/Tests/Actions/IndexTest.php
+```
+Test env vars come from `phpunit.xml.dist` (`FORK_ENV=test`, `APP_ENV=test`). CI seeds a MySQL DB from `tests/data/test_db.sql` before running — a local run needs a working DB configured in `app/config/parameters.yml`.
+
+### Static analysis & code style (PHP)
+```bash
+php bin/phpstan analyse                 # level 1, configured in phpstan.dist.neon, scoped to src/
+php bin/phpcs                           # PSR2, scoped to src/, cache in .phpcs-cache
+php bin/phpcbf                          # auto-fix phpcs violations
+php bin/twig-cs-fixer lint templates/   # Twig template lint (Symfony + Twig standards)
+```
+
+### Frontend assets
+```bash
+npm ci
+npm run build           # webpack --config webpack.prod.js
+npm run watch           # webpack --watch --config webpack.dev.js
+node_modules/.bin/gulp build   # legacy gulp pipeline, still used in CI build stage
+npm test                # runs `standard` (StandardJS linter, see package.json "standard" config for excluded legacy files)
+stylelint .              # SCSS/CSS lint, config in .stylelintrc
+```
+
+### Console utilities of note (`bin/`)
+`bin/console` (Symfony console), `bin/doctrine` / `bin/doctrine-dbal`, `bin/phpstan`, `bin/phpcs` / `bin/phpcbf`, `bin/twigcs`, `bin/sql-formatter`, `bin/generate-parameters-gitlab` (used by CI to build `parameters.yml`).
+
+## Architecture
+
+### Two front-ends, one kernel
+The app is split into two independently-routed applications sharing one Symfony kernel (`app/AppKernel.php` / `app/Kernel.php`):
+- **`src/Backend`** — the CMS administration interface, mounted at `/private/{_locale}/{module}/{action}`.
+- **`src/Frontend`** — the public website, catch-all route `/{route}`.
+
+Both are dispatched through a single Symfony controller, `ForkCMS\App\ForkController` (see `app/config/routing.yml`): `backendController`, `backendAjaxController`, `frontendController`, `frontendAjaxController`. Symfony routing resolves to this controller, which then hands off to ForkCMS's own module/action resolution — most business logic is NOT reached via normal Symfony controller routing/services, but via the module system below.
+
+### Module system (the core convention to understand)
+Both `src/Backend/Modules/*` and `src/Frontend/Modules/*` follow the same per-module layout. Take `src/Backend/Modules/Blog` as a representative example:
+- `info.xml` — module metadata (name, version, description, authors).
+- `Config.php` — extends `Backend\Core\Engine\Base\Config`; declares the module's default action and access control.
+- `Actions/*.php` — one class per admin screen/operation (`Index.php`, `Add.php`, `Edit.php`, `Delete.php`, ...), each extending a base action in `src/Backend/Core/Engine/Base/Action.php` (or `ActionIndex`, `ActionAdd`, `ActionEdit`, `ActionDelete` convenience subclasses).
+- `Ajax/*.php` — AJAX endpoints, extending `Backend\Core\Engine\Base\AjaxAction`.
+- `Engine/Model.php` — static-method "model" class holding the module's DB queries/business logic (not a Doctrine entity — this is the older Fork CMS data-access convention; some newer modules mix in Doctrine).
+- `Widgets/*.php` — reusable blocks embeddable elsewhere (e.g. on Frontend pages), extending `Backend\Core\Engine\Base\Widget`.
+- `Installer/Installer.php` + `Installer/Data/` — module install/upgrade logic (creates DB tables, default settings, locale entries) run by the extensions installer.
+- `Form/`, `Layout/` (templates), `Js/`, `DataFixtures/`, `Tests/` — as named.
+
+`Frontend` modules mirror this (`Actions/`, `Widgets/`, `Engine/Model.php`) but serve public pages instead of admin screens.
+
+When adding a feature to an existing module, follow the existing sibling files in that module (e.g. copy the shape of `Edit.php`/`EditCategory.php` rather than inventing a new pattern). When behavior is core/shared rather than module-specific, it likely belongs in `src/Backend/Core/Engine/` or `src/Frontend/Core/Engine/` (base classes: `Action`, `Model`, `Header`, `Meta`, `Url`, `DataGrid*`, `TwigTemplate`, `Navigation`, `User`, `Authentication`, `Form`).
+
+### Shared/common code
+- `src/Common/` — code shared between Backend and Frontend that isn't module-specific: `Core/`, `Doctrine/` (custom types, subscribers), `EventListener/`, `Events/`, `Mailer/`, `Language.php`, `Locale.php`, `ModulesSettings.php`, `WebTestCase.php` (functional test base class).
+- `src/ForkCMS/` — actual Symfony bundle territory: `Bundle/` (`InstallerBundle`, `CoreBundle`), plus `Google/`, `Imagine/`, `Privacy/`, `Utility/` integration code. This is where you'd add genuinely Symfony-bundle-shaped code (DI extensions, compiler passes).
+- `src/Console/` — custom `bin/console` commands (`Core/`, `Locale/`, `Thumbnails/`).
+- `app/` — kernel bootstrap (`AppKernel.php`, `Kernel.php`, `KernelLoader.php`), `BaseModel.php`, `ForkController.php` (the routing entrypoint described above), and `app/config/*.yml` (Symfony config split by env: `config.yml`, `config_dev.yml`, `config_prod.yml`, `config_test.yml`, `config_install.yml`; plus `routing*.yml`, `doctrine.yml`, `form.yml`, `parameters.yml` — copy `parameters.yml.dist` locally, never edit `.dist`).
+
+### Installer
+Fork CMS ships its own installer bundle (`src/ForkCMS/Bundle/InstallerBundle`) plus a per-module `Installer/Installer.php` convention — new modules need an installer class to create their schema/default data, not a Doctrine migration.
+
+### Config/env
+- `.env` / `.env.local` set `FORK_ENV` and `FORK_DEBUG` (Fork's own env flags, read alongside Symfony's `APP_ENV`/`APP_DEBUG`).
+- `app/config/parameters.yml` holds DB credentials, `kernel.secret`, site settings (`site.protocol`, `site.domain`, `site.multilanguage`, ...), mailer DSN, Sentry DSN. Never commit real values — work from `parameters.yml.dist`.
+
+## Code style specifics
+- PHP: PSR2 via phpcs (`phpcs.xml.dist`), scoped to `src/` only (excludes `Cache/`, `Core/Js/ckeditor`, `Core/Js/ckfinder`).
+- PHPStan level 1 (`phpstan.dist.neon`) against `src/`; a large `ignoreErrors` list suppresses false positives on Fork's legacy global constants (`BACKEND_PATH`, `FRONTEND_CACHE_PATH`, `SITE_URL`, etc.) — don't try to "fix" those by defining the constants, they're intentionally dynamic/runtime-injected.
+- JS: StandardJS (`package.json` `"standard"` block has a long `ignore` list of legacy/vendored JS — don't lint-fix those files opportunistically).
+- SCSS/CSS: stylelint-config-standard-scss with `at-rule-no-unknown`, `no-descending-specificity`, `scss/no-global-function-names` disabled.
+- Twig: twig-cs-fixer with TwigCsFixer + Symfony + Twig standards combined.
+- Indentation: 4 spaces for php/js/yml, 2 spaces for html/twig/xml/tpl (see `.editorconfig`), LF line endings, final newline required.

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -3,6 +3,7 @@ imports:
     - { resource: form.yml }
     - { resource: parameters.yml }
     - { resource: doctrine.yml }
+    - { resource: sitemap.yml }
 
 parameters:
     fork.is_installed: true

--- a/app/config/sitemap.yml
+++ b/app/config/sitemap.yml
@@ -1,0 +1,22 @@
+services:
+    Console\Sitemap\GenerateSitemapCommand:
+        public: true
+        tags:
+            - { name: console.command }
+        arguments:
+            $providers: !tagged sitemap.url_provider
+            $projectDir: '%kernel.project_dir%'
+
+    Common\Sitemap\PagesSitemapUrlProvider:
+        public: true
+        arguments:
+            $database: '@database'
+        tags:
+            - { name: sitemap.url_provider }
+
+    Common\Sitemap\FaqSitemapUrlProvider:
+        public: true
+        arguments:
+            $database: '@database'
+        tags:
+            - { name: sitemap.url_provider }

--- a/app/config/sitemap.yml
+++ b/app/config/sitemap.yml
@@ -1,11 +1,15 @@
 services:
-    Console\Sitemap\GenerateSitemapCommand:
+    Common\Sitemap\SitemapGenerator:
         public: true
-        tags:
-            - { name: console.command }
         arguments:
             $providers: !tagged sitemap.url_provider
             $projectDir: '%kernel.project_dir%'
+
+    Console\Sitemap\GenerateSitemapCommand:
+        public: true
+        autowire: true
+        tags:
+            - { name: console.command }
 
     Common\Sitemap\PagesSitemapUrlProvider:
         public: true
@@ -15,6 +19,13 @@ services:
             - { name: sitemap.url_provider }
 
     Common\Sitemap\FaqSitemapUrlProvider:
+        public: true
+        arguments:
+            $database: '@database'
+        tags:
+            - { name: sitemap.url_provider }
+
+    Common\Sitemap\BlogSitemapUrlProvider:
         public: true
         arguments:
             $database: '@database'

--- a/deploy.php
+++ b/deploy.php
@@ -231,6 +231,10 @@ task('fork:migrations:locale:run', function () {
     }
 })->desc('Run locale migrations');
 
+task('fork:sitemap:generate', function () {
+    run('{{bin/console}} forkcms:sitemap:generate --env={{symfony_env}}');
+})->desc('Generate sitemap.xml');
+
 task(
     'fork:database:backup',
     function () {
@@ -261,3 +265,5 @@ after('deploy:update_code', 'fork:theme:build');
 after('fork:theme:build', 'fork:theme:upload');
 // Clear Fork CMS cache after deploy
 before('deploy:cache:clear', 'fork:cache:clear');
+// Generate the sitemap after cache is cleared
+after('fork:cache:clear', 'fork:sitemap:generate');

--- a/src/Backend/Modules/Settings/Ajax/GenerateSitemap.php
+++ b/src/Backend/Modules/Settings/Ajax/GenerateSitemap.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Backend\Modules\Settings\Ajax;
+
+use Backend\Core\Engine\Base\AjaxAction;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\HttpFoundation\Response;
+
+class GenerateSitemap extends AjaxAction
+{
+    public function execute(): void
+    {
+        parent::execute();
+
+        $kernel = $this->getKernel();
+        $application = new Application($kernel);
+        $application->setAutoExit(false);
+
+        $input = new ArrayInput(
+            [
+                'command' => 'forkcms:sitemap:generate',
+            ]
+        );
+
+        $exitCode = $application->run($input);
+
+        $this->output(
+            Response::HTTP_OK,
+            [
+                'exitCode' => $exitCode,
+            ]
+        );
+    }
+}

--- a/src/Backend/Modules/Settings/Ajax/GenerateSitemap.php
+++ b/src/Backend/Modules/Settings/Ajax/GenerateSitemap.php
@@ -3,8 +3,7 @@
 namespace Backend\Modules\Settings\Ajax;
 
 use Backend\Core\Engine\Base\AjaxAction;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArrayInput;
+use Common\Sitemap\SitemapGenerator;
 use Symfony\Component\HttpFoundation\Response;
 
 class GenerateSitemap extends AjaxAction
@@ -13,23 +12,14 @@ class GenerateSitemap extends AjaxAction
     {
         parent::execute();
 
-        $kernel = $this->getKernel();
-        $application = new Application($kernel);
-        $application->setAutoExit(false);
+        try {
+            $count = $this->get(SitemapGenerator::class)->generate();
+        } catch (\Throwable $e) {
+            $this->output(Response::HTTP_INTERNAL_SERVER_ERROR, null, $e->getMessage());
 
-        $input = new ArrayInput(
-            [
-                'command' => 'forkcms:sitemap:generate',
-            ]
-        );
+            return;
+        }
 
-        $exitCode = $application->run($input);
-
-        $this->output(
-            Response::HTTP_OK,
-            [
-                'exitCode' => $exitCode,
-            ]
-        );
+        $this->output(Response::HTTP_OK, ['count' => $count]);
     }
 }

--- a/src/Backend/Modules/Settings/Installer/Data/locale.xml
+++ b/src/Backend/Modules/Settings/Installer/Data/locale.xml
@@ -415,6 +415,22 @@
         <translation language="en"><![CDATA[The cache has been successfully cleared.]]></translation>
         <translation language="pl"><![CDATA[Pamięć podręczna została pomyślnie wyczyszczona.]]></translation>
       </item>
+      <item type="label" name="GenerateSitemap">
+        <translation language="nl"><![CDATA[genereer sitemap]]></translation>
+        <translation language="en"><![CDATA[generate sitemap]]></translation>
+      </item>
+      <item type="message" name="GenerateSitemap">
+        <translation language="nl"><![CDATA[Genereer de sitemap.xml opnieuw voor alle actieve talen.]]></translation>
+        <translation language="en"><![CDATA[Regenerate the sitemap.xml for all active languages.]]></translation>
+      </item>
+      <item type="message" name="GeneratingSitemap">
+        <translation language="nl"><![CDATA[De sitemap wordt gegenereerd, even geduld]]></translation>
+        <translation language="en"><![CDATA[The sitemap is being generated, hang on]]></translation>
+      </item>
+      <item type="message" name="SitemapGenerated">
+        <translation language="nl"><![CDATA[De sitemap werd succesvol gegenereerd.]]></translation>
+        <translation language="en"><![CDATA[The sitemap was generated successfully.]]></translation>
+      </item>
       <item type="label" name="LinkedPagesPerLanguage">
         <translation language="nl"><![CDATA[gelinkte pagina's per taal]]></translation>
         <translation language="en"><![CDATA[linked pages per language]]></translation>

--- a/src/Backend/Modules/Settings/Js/Settings.js
+++ b/src/Backend/Modules/Settings/Js/Settings.js
@@ -118,14 +118,7 @@ jsBackend.settings = {
           }
         },
         success: function (data) {
-          // if the command exited with exit code 0, it was successful
-          if (data.data.exitCode === 0) {
-            jsBackend.messages.add('success', jsBackend.locale.msg('SitemapGenerated'))
-            return
-          }
-
-          // not so successful if it exited with anything else
-          jsBackend.messages.add('danger', jsBackend.locale.err('SomethingWentWrong'))
+          jsBackend.messages.add('success', jsBackend.locale.msg('SitemapGenerated'))
         },
         error: function () {
           // show error in case something goes wrong with the call itself

--- a/src/Backend/Modules/Settings/Js/Settings.js
+++ b/src/Backend/Modules/Settings/Js/Settings.js
@@ -4,6 +4,7 @@
 jsBackend.settings = {
   init: function () {
     $('[data-role="fork-clear-cache"]').on('click', jsBackend.settings.clearCache)
+    $('[data-role="fork-generate-sitemap"]').on('click', jsBackend.settings.generateSitemap)
 
     $('#activeLanguages input:checkbox').on('change', jsBackend.settings.changeActiveLanguage).change()
 
@@ -83,6 +84,61 @@ jsBackend.settings = {
           // reset the button
           $clearCacheButton.on('click', jsBackend.settings.clearCache)
           $clearCacheButton.attr('disabled', false)
+        }
+      }
+    )
+  },
+
+  generateSitemap: function (e) {
+    // prevent default
+    e.preventDefault()
+
+    // save the button for later use
+    var $generateSitemapButton = $('[data-role="fork-generate-sitemap"]')
+
+    // disable the handler to prevent sending too many requests
+    $generateSitemapButton.off('click', jsBackend.settings.generateSitemap)
+    $generateSitemapButton.attr('disabled', 'disabled')
+
+    // display the status alert
+    var $statusAlert = $('[data-role="fork-generate-sitemap-status"]')
+    $statusAlert.toggleClass('hidden')
+
+    // start the dot animation
+    var dotAnimation = jsBackend.settings.startDotAnimation()
+
+    // start the action
+    $.ajax(
+      {
+        timeout: 60000, // we need this in case generating the sitemap takes a while
+        data: {
+          fork: {
+            module: 'Settings',
+            action: 'GenerateSitemap'
+          }
+        },
+        success: function (data) {
+          // if the command exited with exit code 0, it was successful
+          if (data.data.exitCode === 0) {
+            jsBackend.messages.add('success', jsBackend.locale.msg('SitemapGenerated'))
+            return
+          }
+
+          // not so successful if it exited with anything else
+          jsBackend.messages.add('danger', jsBackend.locale.err('SomethingWentWrong'))
+        },
+        error: function () {
+          // show error in case something goes wrong with the call itself
+          jsBackend.messages.add('danger', jsBackend.locale.err('SomethingWentWrong'))
+        },
+        complete: function () {
+          // stop the dot animation
+          jsBackend.settings.stopDotAnimation(dotAnimation)
+          // hide the status
+          $statusAlert.toggleClass('hidden')
+          // reset the button
+          $generateSitemapButton.on('click', jsBackend.settings.generateSitemap)
+          $generateSitemapButton.attr('disabled', false)
         }
       }
     )

--- a/src/Backend/Modules/Settings/Layout/Templates/Tools.html.twig
+++ b/src/Backend/Modules/Settings/Layout/Templates/Tools.html.twig
@@ -18,6 +18,22 @@
           </div>
         </div>
       </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h2 class="panel-title">
+            {{ 'lbl.GenerateSitemap'|trans|ucfirst }}
+          </h2>
+        </div>
+        <div class="panel-body">
+          <p class="help-block">{{ 'msg.GenerateSitemap'|trans }}</p>
+          <a href="#" data-role="fork-generate-sitemap" class="btn btn-primary">{{ 'lbl.GenerateSitemap'|trans|ucfirst }}</a>
+          <div class="alert alert-warning hidden" role="alert" data-role="fork-generate-sitemap-status">
+            {{ 'msg.GeneratingSitemap'|trans }}
+            <span data-role="fork-dots-animation"></span>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/src/Common/Sitemap/BlogSitemapUrlProvider.php
+++ b/src/Common/Sitemap/BlogSitemapUrlProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Common\Sitemap;
+
+use Frontend\Core\Engine\Navigation as FrontendNavigation;
+use SpoonDatabase;
+
+final class BlogSitemapUrlProvider implements SitemapUrlProviderInterface
+{
+    public function __construct(private SpoonDatabase $database)
+    {
+    }
+
+    public function getUrls(string $locale): array
+    {
+        $records = (array) $this->database->getRecords(
+            'SELECT i.id, i.publish_on, m.url, m.seo_index
+             FROM blog_posts AS i
+             INNER JOIN meta AS m ON i.meta_id = m.id
+             WHERE i.status = ? AND i.hidden = ? AND i.language = ? AND i.publish_on <= ?',
+            ['active', false, $locale, gmdate('Y-m-d H:i:s')]
+        );
+
+        if (empty($records)) {
+            return [];
+        }
+
+        $basePath = FrontendNavigation::getUrlForBlock('Blog', 'Detail', $locale);
+        $siteUrl = rtrim(SITE_URL, '/');
+
+        $urls = [];
+        foreach ($records as $record) {
+            if ($record['seo_index'] === 'noindex') {
+                continue;
+            }
+
+            $urls[] = new SitemapUrl(
+                loc: $siteUrl . '/' . ltrim($basePath, '/') . '/' . $record['url'],
+                lastmod: new \DateTimeImmutable($record['publish_on']),
+                changefreq: 'weekly',
+                priority: 0.6,
+            );
+        }
+
+        return $urls;
+    }
+}

--- a/src/Common/Sitemap/FaqSitemapUrlProvider.php
+++ b/src/Common/Sitemap/FaqSitemapUrlProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Common\Sitemap;
+
+use Frontend\Core\Engine\Navigation as FrontendNavigation;
+use SpoonDatabase;
+
+final class FaqSitemapUrlProvider implements SitemapUrlProviderInterface
+{
+    public function __construct(private SpoonDatabase $database)
+    {
+    }
+
+    public function getUrls(string $locale): array
+    {
+        $records = (array) $this->database->getRecords(
+            'SELECT i.id, m.url, m.seo_index
+             FROM faq_questions AS i
+             INNER JOIN meta AS m ON i.meta_id = m.id
+             WHERE i.hidden = ? AND i.language = ?',
+            [false, $locale]
+        );
+
+        if (empty($records)) {
+            return [];
+        }
+
+        $basePath = FrontendNavigation::getUrlForBlock('Faq', 'Detail', $locale);
+        $siteUrl = rtrim(SITE_URL, '/');
+
+        $urls = [];
+        foreach ($records as $record) {
+            if ($record['seo_index'] === 'noindex') {
+                continue;
+            }
+
+            $urls[] = new SitemapUrl(
+                loc: $siteUrl . '/' . ltrim($basePath, '/') . '/' . $record['url'],
+                changefreq: 'monthly',
+                priority: 0.5,
+            );
+        }
+
+        return $urls;
+    }
+}

--- a/src/Common/Sitemap/PagesSitemapUrlProvider.php
+++ b/src/Common/Sitemap/PagesSitemapUrlProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Common\Sitemap;
+
+use Frontend\Core\Engine\Navigation as FrontendNavigation;
+use SpoonDatabase;
+
+final class PagesSitemapUrlProvider implements SitemapUrlProviderInterface
+{
+    public function __construct(private SpoonDatabase $database)
+    {
+    }
+
+    public function getUrls(string $locale): array
+    {
+        $records = (array) $this->database->getRecords(
+            'SELECT i.id, m.seo_index
+             FROM pages AS i
+             INNER JOIN meta AS m ON i.meta_id = m.id
+             WHERE i.status = ? AND i.hidden = ? AND i.language = ? AND i.id != ?',
+            ['active', 'N', $locale, 404]
+        );
+
+        if (empty($records)) {
+            return [];
+        }
+
+        $siteUrl = rtrim(SITE_URL, '/');
+
+        $urls = [];
+        foreach ($records as $record) {
+            if ($record['seo_index'] === 'noindex') {
+                continue;
+            }
+
+            $path = FrontendNavigation::getUrl((int) $record['id'], $locale);
+
+            $urls[] = new SitemapUrl(
+                loc: $siteUrl . '/' . ltrim($path, '/'),
+                changefreq: 'weekly',
+                priority: 0.8,
+            );
+        }
+
+        return $urls;
+    }
+}

--- a/src/Common/Sitemap/SitemapGenerator.php
+++ b/src/Common/Sitemap/SitemapGenerator.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Common\Sitemap;
+
+use Backend\Core\Language\Language;
+
+final class SitemapGenerator
+{
+    /** @param iterable<SitemapUrlProviderInterface> $providers */
+    public function __construct(private iterable $providers, private string $projectDir)
+    {
+    }
+
+    public function generate(): int
+    {
+        $urls = [];
+
+        foreach (Language::getActiveLanguages() as $locale) {
+            foreach ($this->providers as $provider) {
+                array_push($urls, ...$provider->getUrls($locale));
+            }
+        }
+
+        file_put_contents($this->projectDir . '/sitemap.xml', $this->buildXml($urls));
+
+        return count($urls);
+    }
+
+    /** @param SitemapUrl[] $urls */
+    private function buildXml(array $urls): string
+    {
+        $writer = new \XMLWriter();
+        $writer->openMemory();
+        $writer->setIndent(true);
+        $writer->setIndentString('  ');
+        $writer->startDocument('1.0', 'UTF-8');
+        $writer->startElement('urlset');
+        $writer->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+
+        foreach ($urls as $url) {
+            $writer->startElement('url');
+            $writer->writeElement('loc', $url->loc);
+            if ($url->lastmod !== null) {
+                $writer->writeElement('lastmod', $url->lastmod->format('Y-m-d'));
+            }
+            if ($url->changefreq !== null) {
+                $writer->writeElement('changefreq', $url->changefreq);
+            }
+            if ($url->priority !== null) {
+                $writer->writeElement('priority', number_format($url->priority, 1));
+            }
+            $writer->endElement();
+        }
+
+        $writer->endElement();
+        $writer->endDocument();
+
+        return $writer->outputMemory();
+    }
+}

--- a/src/Common/Sitemap/SitemapUrl.php
+++ b/src/Common/Sitemap/SitemapUrl.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Common\Sitemap;
+
+final class SitemapUrl
+{
+    public string $loc;
+    public ?\DateTimeInterface $lastmod;
+    public ?string $changefreq;
+    public ?float $priority;
+
+    public function __construct(
+        string $loc,
+        ?\DateTimeInterface $lastmod = null,
+        ?string $changefreq = null,
+        ?float $priority = null
+    ) {
+        $this->loc = $loc;
+        $this->lastmod = $lastmod;
+        $this->changefreq = $changefreq;
+        $this->priority = $priority;
+    }
+}

--- a/src/Common/Sitemap/SitemapUrlProviderInterface.php
+++ b/src/Common/Sitemap/SitemapUrlProviderInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Common\Sitemap;
+
+interface SitemapUrlProviderInterface
+{
+    /** @return SitemapUrl[] */
+    public function getUrls(string $locale): array;
+}

--- a/src/Console/Sitemap/GenerateSitemapCommand.php
+++ b/src/Console/Sitemap/GenerateSitemapCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Console\Sitemap;
+
+use Backend\Core\Language\Language;
+use Common\Sitemap\SitemapUrl;
+use Common\Sitemap\SitemapUrlProviderInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class GenerateSitemapCommand extends Command
+{
+    /** @param iterable<SitemapUrlProviderInterface> $providers */
+    public function __construct(private iterable $providers, private string $projectDir)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('forkcms:sitemap:generate')
+            ->setDescription('Generate sitemap.xml for all active languages');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $urls = [];
+
+        foreach (Language::getActiveLanguages() as $locale) {
+            foreach ($this->providers as $provider) {
+                array_push($urls, ...$provider->getUrls($locale));
+            }
+        }
+
+        file_put_contents($this->projectDir . '/sitemap.xml', $this->buildXml($urls));
+
+        $io->success(sprintf('Sitemap generated with %d URLs.', count($urls)));
+
+        return 0;
+    }
+
+    /** @param SitemapUrl[] $urls */
+    private function buildXml(array $urls): string
+    {
+        $writer = new \XMLWriter();
+        $writer->openMemory();
+        $writer->setIndent(true);
+        $writer->setIndentString('  ');
+        $writer->startDocument('1.0', 'UTF-8');
+        $writer->startElement('urlset');
+        $writer->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+
+        foreach ($urls as $url) {
+            $writer->startElement('url');
+            $writer->writeElement('loc', $url->loc);
+            if ($url->lastmod !== null) {
+                $writer->writeElement('lastmod', $url->lastmod->format('Y-m-d'));
+            }
+            if ($url->changefreq !== null) {
+                $writer->writeElement('changefreq', $url->changefreq);
+            }
+            if ($url->priority !== null) {
+                $writer->writeElement('priority', number_format($url->priority, 1));
+            }
+            $writer->endElement();
+        }
+
+        $writer->endElement();
+        $writer->endDocument();
+
+        return $writer->outputMemory();
+    }
+}

--- a/src/Console/Sitemap/GenerateSitemapCommand.php
+++ b/src/Console/Sitemap/GenerateSitemapCommand.php
@@ -2,9 +2,7 @@
 
 namespace Console\Sitemap;
 
-use Backend\Core\Language\Language;
-use Common\Sitemap\SitemapUrl;
-use Common\Sitemap\SitemapUrlProviderInterface;
+use Common\Sitemap\SitemapGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -12,8 +10,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class GenerateSitemapCommand extends Command
 {
-    /** @param iterable<SitemapUrlProviderInterface> $providers */
-    public function __construct(private iterable $providers, private string $projectDir)
+    public function __construct(private SitemapGenerator $sitemapGenerator)
     {
         parent::__construct();
     }
@@ -28,50 +25,11 @@ final class GenerateSitemapCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $urls = [];
 
-        foreach (Language::getActiveLanguages() as $locale) {
-            foreach ($this->providers as $provider) {
-                array_push($urls, ...$provider->getUrls($locale));
-            }
-        }
+        $count = $this->sitemapGenerator->generate();
 
-        file_put_contents($this->projectDir . '/sitemap.xml', $this->buildXml($urls));
-
-        $io->success(sprintf('Sitemap generated with %d URLs.', count($urls)));
+        $io->success(sprintf('Sitemap generated with %d URLs.', $count));
 
         return 0;
-    }
-
-    /** @param SitemapUrl[] $urls */
-    private function buildXml(array $urls): string
-    {
-        $writer = new \XMLWriter();
-        $writer->openMemory();
-        $writer->setIndent(true);
-        $writer->setIndentString('  ');
-        $writer->startDocument('1.0', 'UTF-8');
-        $writer->startElement('urlset');
-        $writer->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-
-        foreach ($urls as $url) {
-            $writer->startElement('url');
-            $writer->writeElement('loc', $url->loc);
-            if ($url->lastmod !== null) {
-                $writer->writeElement('lastmod', $url->lastmod->format('Y-m-d'));
-            }
-            if ($url->changefreq !== null) {
-                $writer->writeElement('changefreq', $url->changefreq);
-            }
-            if ($url->priority !== null) {
-                $writer->writeElement('priority', number_format($url->priority, 1));
-            }
-            $writer->endElement();
-        }
-
-        $writer->endElement();
-        $writer->endDocument();
-
-        return $writer->outputMemory();
     }
 }


### PR DESCRIPTION
## Summary

Adds a `sitemap.xml` generator to Fork CMS.

## How it works

**Providers.** A `Common\Sitemap\SitemapUrlProviderInterface` defines one method, `getUrls(string $locale): SitemapUrl[]`. Any service tagged `sitemap.url_provider` is picked up automatically. Two providers ship with core:
- `Common\Sitemap\PagesSitemapUrlProvider` — all active, non-hidden pages (excluding the 404 page) that aren't marked `noindex`.
- `Common\Sitemap\FaqSitemapUrlProvider` — all visible FAQ questions that aren't marked `noindex`.

Each `SitemapUrl` carries a `loc` (absolute URL) and optional `lastmod`, `changefreq`, `priority`.

**Generation.** `Console\Sitemap\GenerateSitemapCommand` (registered as `forkcms:sitemap:generate`) loops over every active language (`Backend\Core\Language\Language::getActiveLanguages()`), asks each tagged provider for its URLs per locale, and writes the combined result as `sitemap.xml` in the project root using `sitemap.org`'s `urlset` schema.

```bash
php bin/console forkcms:sitemap:generate
```

**Wiring.** `app/config/sitemap.yml` (imported from `config.yml`) registers the command with `$providers: !tagged sitemap.url_provider`, and tags the two core providers. A new module can add its own provider by implementing the interface and tagging its service the same way — no changes to the command are needed.

**Backend trigger.** Settings → Tools gets a "generate sitemap" button (mirrors the existing "clear cache" button/pattern) that runs the console command via AJAX (`Backend\Modules\Settings\Ajax\GenerateSitemap`) and reports success/failure.

**Deploys.** `deploy.php` runs `fork:sitemap:generate` after `fork:cache:clear` on every deploy, so the sitemap stays fresh automatically. `sitemap.xml` itself is gitignored since it's generated output.

## Extending it

To include another module's pages in the sitemap, add a class implementing `SitemapUrlProviderInterface` and register it with the `sitemap.url_provider` tag in that module's `services.yml`, e.g.:

```yaml
Backend\Modules\Blog\Sitemap\BlogSitemapUrlProvider:
    autowire: true
    tags:
        - { name: sitemap.url_provider }
```

## Test plan

- [x] `composer install`
- [x] `php bin/console forkcms:sitemap:generate` produces a valid `sitemap.xml` at the project root
- [x] Settings → Tools → "generate sitemap" button works and shows a success message
- [x] `phpcs`/`phpstan` pass on the new files


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a pluggable sitemap.xml generation system, expose it via a console command, backend tools UI, and deployments, and seed initial providers for core modules.

New Features:
- Introduce a sitemap.xml console command that aggregates URLs from tagged sitemap providers and generates a sitemap for all active languages.
- Add sitemap URL provider implementations for core Pages and FAQ content, excluding noindex and hidden items.
- Expose a backend Settings → Tools action to trigger sitemap generation asynchronously from the admin UI.

Enhancements:
- Wire sitemap services through dedicated Symfony config, enabling other modules to contribute URLs via a common provider interface.
- Extend deployment scripts to regenerate sitemap.xml automatically after cache clears.
- Document repository setup, tooling, and conventions for contributors in a new CLAUDE.md guide.

Build:
- Import sitemap-specific service configuration into the main Symfony config to register the command and providers.